### PR TITLE
Dashboard: fix sparkline chart scrolling/layout bug

### DIFF
--- a/src/flora/dashboard/templates/index.html
+++ b/src/flora/dashboard/templates/index.html
@@ -255,7 +255,9 @@
     <!-- Moisture sparkline -->
     <div style="border-top: 1px solid var(--border); padding-top: 0.75rem;">
         <div style="font-family: 'JetBrains Mono', monospace; font-size: 0.58rem; letter-spacing: 0.15em; text-transform: uppercase; color: var(--text-dim); margin-bottom: 0.4rem;">7-day moisture</div>
-        <canvas id="chart-{{ p.config.name }}" height="48" style="width:100%; display:block;"></canvas>
+        <div style="position: relative; height: 48px; overflow: hidden;">
+            <canvas id="chart-{{ p.config.name }}" style="display:block;"></canvas>
+        </div>
         <div id="chart-{{ p.config.name }}-empty" style="display:none; font-size:0.72rem; color:var(--text-dim); padding: 0.5rem 0;">No data yet</div>
     </div>
 
@@ -302,6 +304,7 @@
                         animation: false,
                         responsive: true,
                         maintainAspectRatio: false,
+                        resizeDelay: 0,
                         plugins: { legend: { display: false }, tooltip: { enabled: false } },
                         scales: {
                             x: { display: false },


### PR DESCRIPTION
## Summary
- Wrap sparkline `<canvas>` in a `position:relative; height:48px; overflow:hidden` container so Chart.js `responsive:true` mode cannot grow the plant card
- Remove the explicit `height` attribute from the canvas element (container now controls height)
- Add `resizeDelay:0` for snappier redraws on resize

## Test plan
- [ ] Open dashboard with plants configured
- [ ] Verify plant cards maintain consistent height — sparkline area is exactly 48px and does not scroll or expand
- [ ] Resize the browser window and confirm cards stay stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)