### PR TITLE
Agent: include latest plant photo in Claude reasoning context

### DIFF
--- a/src/flora/agent/loop.py
+++ b/src/flora/agent/loop.py
@@ -1,8 +1,10 @@
 """Main Claude agent reasoning loop for Flora."""
 from __future__ import annotations
 
+import base64
 import logging
 from datetime import datetime
+from pathlib import Path
 
 import anthropic
 
@@ -84,14 +86,35 @@ class AgentLoop:
                 )
             )
 
-        user_message = (
+        text_content = (
             f"Current time: {datetime.utcnow().strftime('%Y-%m-%d %H:%M UTC')}\n\n"
             "Please review all plants and take any necessary actions.\n\n"
             + "\n\n".join(plant_contexts)
         )
 
+        # Build user message content blocks — include plant photos when available
+        content: list[dict] = []
+        photos_dir = Path("photos")
+        for plant in self._config.plants:
+            photo_path = _latest_photo(photos_dir, plant.name)
+            if photo_path is not None:
+                try:
+                    b64 = base64.standard_b64encode(photo_path.read_bytes()).decode()
+                    content.append({
+                        "type": "image",
+                        "source": {"type": "base64", "media_type": "image/jpeg", "data": b64},
+                    })
+                    content.append({
+                        "type": "text",
+                        "text": f"[Photo of {plant.name} taken {photo_path.stat().st_mtime:.0f}s ago]",
+                    })
+                except Exception as exc:
+                    logger.warning("Could not attach photo for %s: %s", plant.name, exc)
+
+        content.append({"type": "text", "text": text_content})
+
         messages: list[anthropic.types.MessageParam] = [
-            {"role": "user", "content": user_message}
+            {"role": "user", "content": content}  # type: ignore[list-item]
         ]
 
         # Agentic loop: continue until no more tool calls
@@ -159,3 +182,13 @@ class AgentLoop:
                     entry_type="action",
                     content=f"Fallback watering: moisture was {reading.moisture:.1f}%. Claude API unavailable.",
                 ))
+
+
+def _latest_photo(photos_dir: Path, plant_name: str) -> Path | None:
+    """Return the most recently modified photo for a plant, or None."""
+    if not photos_dir.is_dir():
+        return None
+    candidates = list(photos_dir.glob(f"{plant_name}_*.jpg"))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)

--- a/tests/test_agent_photo.py
+++ b/tests/test_agent_photo.py
@@ -1,0 +1,152 @@
+"""Tests for agent loop photo attachment (issue #15)."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from flora.agent.loop import _latest_photo
+
+
+# ---------------------------------------------------------------------------
+# _latest_photo helper
+# ---------------------------------------------------------------------------
+
+def test_latest_photo_returns_none_when_dir_missing(tmp_path):
+    missing = tmp_path / "no_such_dir"
+    assert _latest_photo(missing, "basil") is None
+
+
+def test_latest_photo_returns_none_when_no_files(tmp_path):
+    assert _latest_photo(tmp_path, "basil") is None
+
+
+def test_latest_photo_returns_most_recent(tmp_path):
+    old = tmp_path / "basil_20260101_070000.jpg"
+    new = tmp_path / "basil_20260315_070000.jpg"
+    old.write_bytes(b"old")
+    new.write_bytes(b"new")
+    import time; time.sleep(0.01)
+    new.touch()  # ensure newer mtime
+    result = _latest_photo(tmp_path, "basil")
+    assert result == new
+
+
+def test_latest_photo_ignores_other_plants(tmp_path):
+    (tmp_path / "mint_20260315_070000.jpg").write_bytes(b"mint")
+    assert _latest_photo(tmp_path, "basil") is None
+
+
+def test_latest_photo_ignores_non_jpg(tmp_path):
+    (tmp_path / "basil_20260315_070000.png").write_bytes(b"png")
+    assert _latest_photo(tmp_path, "basil") is None
+
+
+# ---------------------------------------------------------------------------
+# AgentLoop._run_claude_loop photo attachment
+# ---------------------------------------------------------------------------
+
+async def test_photo_block_included_in_message(tmp_path):
+    """When a photo exists, an image content block must appear in the user message."""
+    import base64
+
+    # Write a small fake JPEG
+    photo = tmp_path / "basil_20260315_070000.jpg"
+    photo.write_bytes(b"\xff\xd8\xff\xe0fake_jpeg_bytes")
+
+    from flora.agent.loop import AgentLoop
+    from flora.config import AppConfig, PlantConfig
+
+    plant = PlantConfig(
+        name="basil",
+        species="basil",
+        sensor_mac="AA:BB:CC:DD:EE:FF",
+        pump_gpio=17,
+        moisture_target_min=40,
+        moisture_target_max=70,
+    )
+    config = MagicMock(spec=AppConfig)
+    config.plants = [plant]
+    config.anthropic_api_key = "test"
+    config.anthropic_model = "claude-3-5-haiku-20241022"
+
+    db = MagicMock()
+    db.get_latest_ambient = AsyncMock(return_value=None)
+    db.get_sensor_history = AsyncMock(return_value=[])
+    db.get_journal = AsyncMock(return_value=[])
+
+    # Fake Claude response — stop immediately (no tool use)
+    fake_response = MagicMock()
+    fake_response.stop_reason = "end_turn"
+    fake_response.content = []
+
+    captured_messages = []
+
+    async def fake_create(**kwargs):
+        captured_messages.extend(kwargs["messages"])
+        return fake_response
+
+    with patch("flora.agent.loop.Path", side_effect=lambda p: tmp_path if p == "photos" else Path(p)):
+        loop = AgentLoop(config, db)
+        loop._client = MagicMock()
+        loop._client.messages = MagicMock()
+        loop._client.messages.create = fake_create
+
+        await loop._run_claude_loop()
+
+    assert captured_messages, "No messages were sent"
+    user_content = captured_messages[0]["content"]
+    assert isinstance(user_content, list), "Content should be a list of blocks"
+
+    image_blocks = [b for b in user_content if b.get("type") == "image"]
+    assert len(image_blocks) == 1, f"Expected 1 image block, got {len(image_blocks)}"
+    assert image_blocks[0]["source"]["media_type"] == "image/jpeg"
+    expected_b64 = base64.standard_b64encode(photo.read_bytes()).decode()
+    assert image_blocks[0]["source"]["data"] == expected_b64
+
+
+async def test_no_photo_block_when_no_photo(tmp_path):
+    """When no photo exists, content should have only text blocks."""
+    from flora.agent.loop import AgentLoop
+    from flora.config import AppConfig, PlantConfig
+
+    plant = PlantConfig(
+        name="mint",
+        species="mint",
+        sensor_mac="AA:BB:CC:DD:EE:01",
+        pump_gpio=18,
+        moisture_target_min=50,
+        moisture_target_max=80,
+    )
+    config = MagicMock(spec=AppConfig)
+    config.plants = [plant]
+    config.anthropic_api_key = "test"
+    config.anthropic_model = "claude-3-5-haiku-20241022"
+
+    db = MagicMock()
+    db.get_latest_ambient = AsyncMock(return_value=None)
+    db.get_sensor_history = AsyncMock(return_value=[])
+    db.get_journal = AsyncMock(return_value=[])
+
+    fake_response = MagicMock()
+    fake_response.stop_reason = "end_turn"
+    fake_response.content = []
+
+    captured_messages = []
+
+    async def fake_create(**kwargs):
+        captured_messages.extend(kwargs["messages"])
+        return fake_response
+
+    with patch("flora.agent.loop.Path", side_effect=lambda p: tmp_path if p == "photos" else Path(p)):
+        loop = AgentLoop(config, db)
+        loop._client = MagicMock()
+        loop._client.messages = MagicMock()
+        loop._client.messages.create = fake_create
+
+        await loop._run_claude_loop()
+
+    user_content = captured_messages[0]["content"]
+    image_blocks = [b for b in user_content if b.get("type") == "image"]
+    assert image_blocks == [], "No image blocks expected when no photo present"


### PR DESCRIPTION
Closes #15

## Summary
- Attaches the most recently modified `photos/{plant_name}_*.jpg` as a base64 `image/jpeg` content block in the Claude API user message, one per plant
- Falls back gracefully (logs warning, skips) if no photo exists or file can't be read
- Adds `_latest_photo(photos_dir, plant_name) -> Path | None` helper

## Tests
7 new tests in `tests/test_agent_photo.py`:
- `_latest_photo` returns `None` when dir missing / no files / wrong plant / non-jpg
- `_latest_photo` returns the most recently modified file when multiple exist
- Integration: verifies image block present in Claude message when photo exists
- Integration: verifies no image blocks when no photo present

## Test plan
- [ ] `pytest tests/test_agent_photo.py -v` → 7 passed
- [ ] `pytest --ignore=tests/test_dashboard_e2e.py -q` → all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)