### PR TITLE
Config: add per-plant auto-water threshold rules

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -17,6 +17,9 @@ class PlantConfig:
     pump_gpio: int        # GPIO pin number for relay
     moisture_target_min: int = 40
     moisture_target_max: int = 70
+    # Optional deterministic auto-water rule (no Claude API needed)
+    auto_water_if_below: int | None = None   # moisture % threshold
+    auto_water_duration_seconds: int = 8     # pump seconds (clamped 5-30)
 
 
 @dataclass(frozen=True)
@@ -67,6 +70,8 @@ def load_config(path: str | Path = "flora.toml") -> AppConfig:
             pump_gpio=p["pump_gpio"],
             moisture_target_min=p.get("moisture_target_min", 40),
             moisture_target_max=p.get("moisture_target_max", 70),
+            auto_water_if_below=p.get("auto_water_if_below"),
+            auto_water_duration_seconds=p.get("auto_water_duration_seconds", 8),
         )
         for p in raw.get("plants", [])
     ]

--- a/src/flora/scheduler.py
+++ b/src/flora/scheduler.py
@@ -3,15 +3,15 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
+from pathlib import Path
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler  # type: ignore[import]
 
 from flora.config import AppConfig
-from flora.db import AmbientReading, Database, SensorReading
+from flora.db import ActionRecord, AmbientReading, Database, SensorReading
 from flora.sensors.miflora import read_miflora
 from flora.sensors.sht31 import read_sht31
 from flora.sensors.bh1750 import read_bh1750
-from pathlib import Path
 
 from flora.agent.loop import AgentLoop
 from flora.notifications import send_daily_summary
@@ -41,6 +41,25 @@ async def _poll_sensors(config: AppConfig, db: Database) -> None:
             battery=reading.battery,
         ))
         logger.debug("Stored reading for %s: moisture=%.1f%%", plant.name, reading.moisture)
+
+        # Auto-water rule: water immediately if configured threshold is breached
+        threshold = plant.auto_water_if_below
+        if threshold is not None and reading.moisture is not None and reading.moisture < threshold:
+            duration = max(5, min(30, plant.auto_water_duration_seconds))
+            logger.info(
+                "Auto-water triggered for %s: moisture=%.1f%% < %d%%",
+                plant.name, reading.moisture, threshold,
+            )
+            from flora.actuators.pump import water_plant as _pump
+            await _pump(plant.pump_gpio, duration)
+            await db.log_action(ActionRecord(
+                plant_name=plant.name,
+                timestamp=now,
+                action_type="auto_water",
+                parameters={"duration_seconds": duration, "moisture": reading.moisture, "threshold": threshold},
+                reasoning=f"Auto-water rule: moisture {reading.moisture:.1f}% < {threshold}%",
+                claude_model="rule",
+            ))
 
     # Poll ambient sensors
     sht31 = await read_sht31()

--- a/tests/test_auto_water.py
+++ b/tests/test_auto_water.py
@@ -1,0 +1,146 @@
+"""Tests for auto-water threshold rules (issue #16)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+
+from flora.config import PlantConfig
+
+
+# ---------------------------------------------------------------------------
+# PlantConfig defaults
+# ---------------------------------------------------------------------------
+
+def test_plant_config_auto_water_defaults():
+    p = PlantConfig(
+        name="basil", species="basil",
+        sensor_mac="AA:BB:CC:DD:EE:FF", pump_gpio=17,
+    )
+    assert p.auto_water_if_below is None
+    assert p.auto_water_duration_seconds == 8
+
+
+def test_plant_config_auto_water_set():
+    p = PlantConfig(
+        name="basil", species="basil",
+        sensor_mac="AA:BB:CC:DD:EE:FF", pump_gpio=17,
+        auto_water_if_below=25,
+        auto_water_duration_seconds=10,
+    )
+    assert p.auto_water_if_below == 25
+    assert p.auto_water_duration_seconds == 10
+
+
+# ---------------------------------------------------------------------------
+# _poll_sensors auto-water trigger
+# ---------------------------------------------------------------------------
+
+def _make_plant(threshold=None, duration=8):
+    return PlantConfig(
+        name="basil", species="basil",
+        sensor_mac="AA:BB:CC:DD:EE:FF", pump_gpio=17,
+        moisture_target_min=40, moisture_target_max=70,
+        auto_water_if_below=threshold,
+        auto_water_duration_seconds=duration,
+    )
+
+
+def _make_miflora_reading(moisture):
+    r = MagicMock()
+    r.moisture = moisture
+    r.temperature = 22.0
+    r.light = 500
+    r.fertility = 200
+    r.battery = 90
+    return r
+
+
+async def test_auto_water_triggers_when_below_threshold():
+    from flora.scheduler import _poll_sensors
+
+    config = MagicMock()
+    config.plants = [_make_plant(threshold=25, duration=10)]
+    db = MagicMock()
+    db.insert_sensor_reading = AsyncMock()
+    db.log_action = AsyncMock()
+    db.insert_ambient_reading = AsyncMock()
+
+    miflora_reading = _make_miflora_reading(moisture=18.0)
+
+    with patch("flora.scheduler.read_miflora", return_value=miflora_reading), \
+         patch("flora.scheduler.read_sht31", return_value=None), \
+         patch("flora.scheduler.read_bh1750", return_value=None), \
+         patch("flora.actuators.pump.water_plant", new=AsyncMock(return_value=True)) as mock_pump:
+        await _poll_sensors(config, db)
+
+    mock_pump.assert_awaited_once_with(17, 10)
+    db.log_action.assert_awaited_once()
+    action = db.log_action.call_args[0][0]
+    assert action.action_type == "auto_water"
+    assert action.claude_model == "rule"
+    assert action.parameters["threshold"] == 25
+
+
+async def test_auto_water_not_triggered_when_above_threshold():
+    from flora.scheduler import _poll_sensors
+
+    config = MagicMock()
+    config.plants = [_make_plant(threshold=25)]
+    db = MagicMock()
+    db.insert_sensor_reading = AsyncMock()
+    db.log_action = AsyncMock()
+    db.insert_ambient_reading = AsyncMock()
+
+    miflora_reading = _make_miflora_reading(moisture=40.0)
+
+    with patch("flora.scheduler.read_miflora", return_value=miflora_reading), \
+         patch("flora.scheduler.read_sht31", return_value=None), \
+         patch("flora.scheduler.read_bh1750", return_value=None), \
+         patch("flora.actuators.pump.water_plant", new=AsyncMock(return_value=True)) as mock_pump:
+        await _poll_sensors(config, db)
+
+    mock_pump.assert_not_awaited()
+    db.log_action.assert_not_awaited()
+
+
+async def test_auto_water_not_triggered_when_threshold_is_none():
+    from flora.scheduler import _poll_sensors
+
+    config = MagicMock()
+    config.plants = [_make_plant(threshold=None)]
+    db = MagicMock()
+    db.insert_sensor_reading = AsyncMock()
+    db.log_action = AsyncMock()
+    db.insert_ambient_reading = AsyncMock()
+
+    miflora_reading = _make_miflora_reading(moisture=5.0)
+
+    with patch("flora.scheduler.read_miflora", return_value=miflora_reading), \
+         patch("flora.scheduler.read_sht31", return_value=None), \
+         patch("flora.scheduler.read_bh1750", return_value=None), \
+         patch("flora.actuators.pump.water_plant", new=AsyncMock(return_value=True)) as mock_pump:
+        await _poll_sensors(config, db)
+
+    mock_pump.assert_not_awaited()
+
+
+async def test_auto_water_duration_clamped_to_5_30():
+    from flora.scheduler import _poll_sensors
+
+    config = MagicMock()
+    config.plants = [_make_plant(threshold=25, duration=99)]  # too high, should clamp to 30
+    db = MagicMock()
+    db.insert_sensor_reading = AsyncMock()
+    db.log_action = AsyncMock()
+    db.insert_ambient_reading = AsyncMock()
+
+    miflora_reading = _make_miflora_reading(moisture=10.0)
+
+    with patch("flora.scheduler.read_miflora", return_value=miflora_reading), \
+         patch("flora.scheduler.read_sht31", return_value=None), \
+         patch("flora.scheduler.read_bh1750", return_value=None), \
+         patch("flora.actuators.pump.water_plant", new=AsyncMock(return_value=True)) as mock_pump:
+        await _poll_sensors(config, db)
+
+    mock_pump.assert_awaited_once_with(17, 30)


### PR DESCRIPTION
Closes #16

## Summary
- `PlantConfig` gains two optional fields: `auto_water_if_below: int | None` and `auto_water_duration_seconds: int = 8`
- `_poll_sensors` in `scheduler.py` checks after each reading: if threshold is set and moisture is below it, calls the pump actuator and logs an `ActionRecord(action_type="auto_water", claude_model="rule")`
- Duration is clamped to 5–30s
- `load_config` reads both fields from TOML (`auto_water_if_below`, `auto_water_duration_seconds`)

## Tests
6 new tests in `tests/test_auto_water.py`:
- Config defaults and field setting
- Pump called when moisture < threshold
- Pump not called when moisture >= threshold
- Pump not called when threshold is None
- Duration clamped to max 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)