### PR TITLE
Dashboard: enhance plant detail page with timeline journal and empty states

### DIFF
--- a/src/flora/dashboard/templates/plant.html
+++ b/src/flora/dashboard/templates/plant.html
@@ -86,10 +86,11 @@
 
     <!-- Chart Card -->
     <div class="card fade-up-3">
-        <div class="card-label">Moisture History — 48h</div>
-        <div style="position: relative; height: 220px;">
+        <div class="card-label">Sensor History — 48h</div>
+        <div style="position: relative; height: 200px;">
             <canvas id="moistureChart"></canvas>
         </div>
+        <div id="chart-empty" style="display:none; font-size:0.75rem; color:var(--text-dim); padding:2rem 0; text-align:center;">No data yet</div>
     </div>
 
 </div>
@@ -133,40 +134,37 @@
 <!-- Journal + Actions -->
 <div class="grid grid-2">
 
-    {% if journal %}
     <div class="section fade-up-4">
         <div class="section-header">
             <h2 class="section-title">Plant Journal</h2>
             <div class="section-rule"></div>
         </div>
-        <div class="card" style="padding: 0;">
-            <div class="table-scroll">
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Time</th>
-                        <th>Type</th>
-                        <th>Entry</th>
-                    </tr>
-                </thead>
-                <tbody>
-                {% for e in journal %}
-                <tr>
-                    <td class="mono" style="color: var(--text-dim); white-space: nowrap; font-size: 0.72rem;">{{ e.timestamp.strftime("%m-%d %H:%M") }}</td>
-                    <td>
-                        <span class="badge badge-{% if e.entry_type == 'observation' %}healthy{% elif e.entry_type == 'alert' %}critical{% else %}unknown{% endif %}" style="font-size: 0.58rem;">
-                            {{ e.entry_type }}
-                        </span>
-                    </td>
-                    <td style="line-height: 1.45;">{{ e.content }}</td>
-                </tr>
-                {% endfor %}
-                </tbody>
-            </table>
+        {% if journal %}
+        <div class="card" style="padding: 1rem 1.25rem;">
+            <div style="display: flex; flex-direction: column; gap: 0;">
+            {% for e in journal %}
+            {% set badge_color = '#4DC8FF' if e.entry_type == 'observation' else ('#00E07A' if e.entry_type == 'action' else ('#FF4D6A' if e.entry_type == 'alert' else '#4A7558')) %}
+            <div style="display: flex; gap: 1rem; padding: 0.75rem 0; {% if not loop.last %}border-bottom: 1px solid rgba(0,220,100,0.06);{% endif %}">
+                <!-- Timeline dot + line -->
+                <div style="display: flex; flex-direction: column; align-items: center; flex-shrink: 0; width: 12px; padding-top: 4px;">
+                    <div style="width: 8px; height: 8px; border-radius: 50%; background: {{ badge_color }}; flex-shrink: 0;"></div>
+                    {% if not loop.last %}<div style="width: 1px; flex: 1; background: rgba(0,220,100,0.1); margin-top: 4px;"></div>{% endif %}
+                </div>
+                <div style="flex: 1; min-width: 0;">
+                    <div style="display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.3rem; flex-wrap: wrap;">
+                        <span style="display: inline-block; padding: 0.12rem 0.5rem; border-radius: 2px; font-family: 'JetBrains Mono', monospace; font-size: 0.55rem; letter-spacing: 0.1em; text-transform: uppercase; background: {{ badge_color }}22; color: {{ badge_color }}; border: 1px solid {{ badge_color }}44;">{{ e.entry_type }}</span>
+                        <span class="mono" style="font-size: 0.62rem; color: var(--text-dim);">{{ e.timestamp.strftime("%b %d, %H:%M") }}</span>
+                    </div>
+                    <div style="font-size: 0.8rem; color: var(--text-muted); line-height: 1.5;">{{ e.content }}</div>
+                </div>
+            </div>
+            {% endfor %}
             </div>
         </div>
+        {% else %}
+        <div class="card" style="text-align: center; padding: 2rem; color: var(--text-dim); font-size: 0.75rem;">No journal entries yet</div>
+        {% endif %}
     </div>
-    {% endif %}
 
     {% if actions %}
     <div class="section fade-up-5">
@@ -214,6 +212,14 @@
     const labels   = readings.map(r => r.ts.slice(5, 16).replace('T', ' '));
     const moisture = readings.map(r => r.moisture);
     const temp     = readings.map(r => r.temperature);
+
+    if (!readings.length) {
+        const empty = document.getElementById("chart-empty");
+        const canvas = document.getElementById("moistureChart");
+        if (empty) empty.style.display = "block";
+        if (canvas) canvas.style.display = "none";
+        return;
+    }
 
     const ctx = document.getElementById("moistureChart");
     if (!ctx) return;


### PR DESCRIPTION
Closes #18

## Summary
- **Journal timeline**: converts the journal from a data table to a vertical dot-and-line timeline. Each entry has a colour-coded badge (observation=blue `#4DC8FF`, action=green `#00E07A`, alert=red `#FF4D6A`, note=accent green) and timestamp alongside the content text
- **Empty states**: shows "No journal entries yet" placeholder card when journal is empty; chart shows "No data yet" and hides the canvas when the history API returns zero readings
- **Chart height**: fixed at `200px` with `position:relative` wrapper (was 220px)
- **No new routes**: uses existing `/api/plants/{name}/history?hours=48` and the `journal` template variable

## Test plan
- [ ] Visit `/plants/{name}` for a plant with journal entries — see timeline with coloured dots
- [ ] Visit for a plant with no journal entries — see "No journal entries yet" card
- [ ] Visit for a plant with no history — chart area shows "No data yet"
- [ ] `pytest --ignore=tests/test_dashboard_e2e.py -q` → all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)