### PR TITLE
Dashboard: add dark/light mode toggle

### DIFF
--- a/src/flora/dashboard/templates/base.html
+++ b/src/flora/dashboard/templates/base.html
@@ -7,6 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500&family=JetBrains+Mono:wght@300;400;500&display=swap" rel="stylesheet">
+    <script>if(localStorage.getItem('flora-theme')==='light')document.documentElement.classList.add('preload-light');</script>
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <style>
@@ -475,6 +476,50 @@
         .fade-up-4 { animation: fade-up 0.45s 0.24s ease both; }
         .fade-up-5 { animation: fade-up 0.45s 0.30s ease both; }
 
+        /* Apply light mode before paint (no flash) */
+        html.preload-light body { --bg:#F5F7F5; --surface:#FFF; --surface2:#EDF2EE; --surface3:#E2EBE3; --border:rgba(0,120,50,0.1); --border-hi:rgba(0,160,70,0.3); --glow:rgba(0,160,70,0.08); --accent:#008844; --accent-dim:#005C2C; --text:#0E1E12; --text-muted:#3A6648; --text-dim:#7AA489; }
+
+        /* LIGHT MODE */
+        body.light-mode {
+            --bg:         #F5F7F5;
+            --surface:    #FFFFFF;
+            --surface2:   #EDF2EE;
+            --surface3:   #E2EBE3;
+            --border:     rgba(0,120,50,0.1);
+            --border-hi:  rgba(0,160,70,0.3);
+            --glow:       rgba(0,160,70,0.08);
+            --accent:     #008844;
+            --accent-dim: #005C2C;
+            --text:       #0E1E12;
+            --text-muted: #3A6648;
+            --text-dim:   #7AA489;
+        }
+        body.light-mode::before {
+            background-image:
+                linear-gradient(rgba(0,120,50,0.04) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(0,120,50,0.04) 1px, transparent 1px);
+        }
+        body.light-mode nav {
+            background: rgba(245,247,245,0.92);
+        }
+
+        /* THEME TOGGLE BUTTON */
+        .theme-toggle {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 32px; height: 32px;
+            border-radius: 6px;
+            border: 1px solid var(--border);
+            background: transparent;
+            cursor: pointer;
+            color: var(--text-muted);
+            margin-left: 0.75rem;
+            transition: color 0.2s, border-color 0.2s;
+            flex-shrink: 0;
+        }
+        .theme-toggle:hover { color: var(--text); border-color: var(--border-hi); }
+
         /* SCROLLBAR */
         ::-webkit-scrollbar { width: 6px; height: 6px; }
         ::-webkit-scrollbar-track { background: var(--bg); }
@@ -580,16 +625,34 @@
             <span class="nav-badge-dot"></span>
             system online
         </div>
+        <button class="theme-toggle" id="themeToggle" aria-label="Toggle light/dark mode" title="Toggle light/dark mode">
+            <svg id="icon-moon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            <svg id="icon-sun" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:none"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+        </button>
         <button class="nav-hamburger" id="navHamburger" aria-label="Toggle menu" aria-expanded="false">
             <span></span><span></span><span></span>
         </button>
     </nav>
     <script>
-        document.getElementById('navHamburger').addEventListener('click', function() {
-            var links = document.getElementById('navLinks');
-            var open = links.classList.toggle('open');
-            this.setAttribute('aria-expanded', open);
-        });
+        (function() {
+            var saved = localStorage.getItem('flora-theme');
+            if (saved === 'light') {
+                document.body.classList.add('light-mode');
+                document.getElementById('icon-moon').style.display = 'none';
+                document.getElementById('icon-sun').style.display = 'block';
+            }
+            document.getElementById('themeToggle').addEventListener('click', function() {
+                var isLight = document.body.classList.toggle('light-mode');
+                localStorage.setItem('flora-theme', isLight ? 'light' : 'dark');
+                document.getElementById('icon-moon').style.display = isLight ? 'none' : 'block';
+                document.getElementById('icon-sun').style.display = isLight ? 'block' : 'none';
+            });
+            document.getElementById('navHamburger').addEventListener('click', function() {
+                var links = document.getElementById('navLinks');
+                var open = links.classList.toggle('open');
+                this.setAttribute('aria-expanded', open);
+            });
+        })();
     </script>
 
     <div class="container">


### PR DESCRIPTION
Closes #19

## Summary
- Sun/moon icon button in the nav bar (right side, before hamburger)
- Toggles `body.light-mode` class and saves `localStorage('flora-theme')`
- Inline script in `<head>` applies saved theme before first paint (no flash)
- Light palette: `#F5F7F5` background, white surfaces, dark text, muted green accents — consistent with the existing dark brand identity at reduced contrast
- Vanilla JS only, no framework

## Test plan
- [ ] Click toggle — dashboard switches to light mode, button shows sun icon
- [ ] Reload page — light mode persists
- [ ] Click toggle again — back to dark mode
- [ ] Works on `/`, `/plants/{name}`, `/actions`, `/logs`
- [ ] `pytest --ignore=tests/test_dashboard_e2e.py -q` → all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)