### PR TITLE
Config: add per-plant camera_index for multi-camera support

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -20,6 +20,8 @@ class PlantConfig:
     # Optional deterministic auto-water rule (no Claude API needed)
     auto_water_if_below: int | None = None   # moisture % threshold
     auto_water_duration_seconds: int = 8     # pump seconds (clamped 5-30)
+    # Camera assignment (index into Picamera2 camera list; None = default 0)
+    camera_index: int | None = None
 
 
 @dataclass(frozen=True)
@@ -72,6 +74,7 @@ def load_config(path: str | Path = "flora.toml") -> AppConfig:
             moisture_target_max=p.get("moisture_target_max", 70),
             auto_water_if_below=p.get("auto_water_if_below"),
             auto_water_duration_seconds=p.get("auto_water_duration_seconds", 8),
+            camera_index=p.get("camera_index"),
         )
         for p in raw.get("plants", [])
     ]

--- a/src/flora/scheduler.py
+++ b/src/flora/scheduler.py
@@ -123,7 +123,11 @@ async def _run_photo_capture(config: AppConfig, db: Database) -> None:
     """Capture a daily photo for each plant."""
     photo_dir = Path("photos")
     for plant in config.plants:
-        result = await capture_photo(plant.name, save_dir=photo_dir)
+        result = await capture_photo(
+            plant.name,
+            save_dir=photo_dir,
+            camera_index=plant.camera_index or 0,
+        )
         if result:
             logger.info("Photo captured for %s: %s", plant.name, result.path)
 

--- a/src/flora/sensors/camera.py
+++ b/src/flora/sensors/camera.py
@@ -21,7 +21,11 @@ class PhotoResult:
     path: Path
 
 
-async def capture_photo(plant_name: str, save_dir: Path) -> PhotoResult | None:
+async def capture_photo(
+    plant_name: str,
+    save_dir: Path,
+    camera_index: int = 0,
+) -> PhotoResult | None:
     """Capture a photo of a plant. Returns None on failure."""
     save_dir.mkdir(parents=True, exist_ok=True)
     ts = datetime.utcnow()
@@ -29,14 +33,16 @@ async def capture_photo(plant_name: str, save_dir: Path) -> PhotoResult | None:
     path = save_dir / filename
 
     if IS_PI:
-        return await _capture_real(plant_name, path, ts)
+        return await _capture_real(plant_name, path, ts, camera_index)
     return _capture_mock(plant_name, path, ts)
 
 
-async def _capture_real(plant_name: str, path: Path, ts: datetime) -> PhotoResult | None:
+async def _capture_real(
+    plant_name: str, path: Path, ts: datetime, camera_index: int = 0
+) -> PhotoResult | None:
     try:
         from picamera2 import Picamera2  # type: ignore[import]
-        cam = Picamera2()
+        cam = Picamera2(camera_num=camera_index)
         cam.configure(cam.create_still_configuration())
         cam.start()
         cam.capture_file(str(path))

--- a/tests/test_camera_index.py
+++ b/tests/test_camera_index.py
@@ -1,0 +1,91 @@
+"""Tests for per-plant camera_index config (issue #26)."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from flora.config import PlantConfig
+
+
+def test_camera_index_defaults_to_none():
+    p = PlantConfig(
+        name="basil", species="basil",
+        sensor_mac="AA:BB:CC:DD:EE:FF", pump_gpio=17,
+    )
+    assert p.camera_index is None
+
+
+def test_camera_index_set():
+    p = PlantConfig(
+        name="mint", species="mint",
+        sensor_mac="AA:BB:CC:DD:EE:01", pump_gpio=18,
+        camera_index=1,
+    )
+    assert p.camera_index == 1
+
+
+async def test_capture_photo_passes_camera_index(tmp_path):
+    """capture_photo forwards camera_index to _capture_real on Pi, mock on dev."""
+    from flora.sensors.camera import capture_photo
+
+    # On non-Pi, mock path is taken — just verify the file is created
+    result = await capture_photo("basil", save_dir=tmp_path, camera_index=1)
+    assert result is not None
+    assert result.plant_name == "basil"
+    assert result.path.exists()
+
+
+async def test_run_photo_capture_passes_plant_camera_index(tmp_path):
+    """_run_photo_capture passes plant.camera_index (or 0) to capture_photo."""
+    from flora.scheduler import _run_photo_capture
+
+    plant = PlantConfig(
+        name="mint", species="mint",
+        sensor_mac="AA:BB:CC:DD:EE:01", pump_gpio=18,
+        camera_index=2,
+    )
+    config = MagicMock()
+    config.plants = [plant]
+    db = MagicMock()
+
+    captured_calls = []
+
+    async def mock_capture(plant_name, save_dir, camera_index=0):
+        captured_calls.append({"plant_name": plant_name, "camera_index": camera_index})
+        r = MagicMock()
+        r.path = tmp_path / f"{plant_name}.jpg"
+        return r
+
+    with patch("flora.scheduler.capture_photo", side_effect=mock_capture):
+        await _run_photo_capture(config, db)
+
+    assert captured_calls == [{"plant_name": "mint", "camera_index": 2}]
+
+
+async def test_run_photo_capture_defaults_to_0_when_camera_index_none(tmp_path):
+    """When camera_index is None, capture_photo is called with camera_index=0."""
+    from flora.scheduler import _run_photo_capture
+
+    plant = PlantConfig(
+        name="basil", species="basil",
+        sensor_mac="AA:BB:CC:DD:EE:FF", pump_gpio=17,
+        camera_index=None,
+    )
+    config = MagicMock()
+    config.plants = [plant]
+    db = MagicMock()
+
+    captured_calls = []
+
+    async def mock_capture(plant_name, save_dir, camera_index=0):
+        captured_calls.append(camera_index)
+        r = MagicMock()
+        r.path = tmp_path / f"{plant_name}.jpg"
+        return r
+
+    with patch("flora.scheduler.capture_photo", side_effect=mock_capture):
+        await _run_photo_capture(config, db)
+
+    assert captured_calls == [0]


### PR DESCRIPTION
Closes #26

## Summary
- `PlantConfig` gains `camera_index: int | None = None`
- `capture_photo(plant_name, save_dir, camera_index=0)` accepts the index; passes `camera_num=camera_index` to `Picamera2` on Pi, ignored in mock
- `_run_photo_capture` passes `plant.camera_index or 0`
- `load_config` reads `camera_index` from TOML

## Tests (5 new in `tests/test_camera_index.py`)
- Config defaults and explicit set
- `capture_photo` creates file with index=1 (mock path)
- `_run_photo_capture` passes plant's camera_index through
- `_run_photo_capture` defaults to 0 when camera_index is None

🤖 Generated with [Claude Code](https://claude.com/claude-code)