### PR TITLE
Dashboard: plant commissioning wizard — scan, assign, test, save

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -49,6 +49,22 @@ class AppConfig:
         return next((p for p in self.smart_plugs if p.role == role), None)
 
 
+def append_plant_to_toml(path: str | Path, plant: dict) -> None:
+    """Append a new [[plants]] entry to flora.toml, preserving all existing content."""
+    config_path = Path(path)
+    existing = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
+
+    lines = ["\n[[plants]]"]
+    for key, value in plant.items():
+        if isinstance(value, str):
+            lines.append(f'{key} = "{value}"')
+        elif value is not None:
+            lines.append(f"{key} = {value}")
+
+    with open(config_path, "a", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+
+
 def load_config(path: str | Path = "flora.toml") -> AppConfig:
     """Load and validate flora.toml, returning a frozen AppConfig."""
     config_path = Path(path)

--- a/src/flora/dashboard/routes.py
+++ b/src/flora/dashboard/routes.py
@@ -5,13 +5,17 @@ import csv
 import io
 import json
 from datetime import datetime
+from pathlib import Path
 
 from fastapi import APIRouter, Form, Request
-from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
 
-from flora.config import AppConfig
+from flora.config import AppConfig, append_plant_to_toml
 from flora.db import Database
+
+# GPIO pins commonly available on Pi for relay use (BCM numbering)
+_CANDIDATE_GPIO_PINS = [4, 17, 18, 22, 23, 24, 25, 27]
 
 
 def create_router(
@@ -51,6 +55,17 @@ def create_router(
             "index.html",
             {"plants": plant_data, "ambient": ambient, "actions": actions,
              "plants_art_json": plants_art_json},
+        )
+
+    @router.get("/plants/new", response_class=HTMLResponse)
+    async def commissioning_page(request: Request) -> HTMLResponse:
+        used_gpio = {p.pump_gpio for p in config.plants}
+        free_gpio = [p for p in _CANDIDATE_GPIO_PINS if p not in used_gpio]
+        used_macs = {p.sensor_mac for p in config.plants}
+        return templates.TemplateResponse(
+            request,
+            "commissioning.html",
+            {"free_gpio": free_gpio, "used_macs": used_macs},
         )
 
     @router.get("/plants/{name}", response_class=HTMLResponse)
@@ -155,6 +170,49 @@ def create_router(
             "actions.html",
             {"actions": actions},
         )
+
+    @router.get("/api/commissioning/scan")
+    async def commissioning_scan() -> JSONResponse:
+        """Scan for nearby Mi Flora BLE sensors not already assigned."""
+        used_macs = {p.sensor_mac for p in config.plants}
+        try:
+            from flora.sensors.miflora import scan_miflora  # type: ignore[import]
+            found = await scan_miflora()
+            new_macs = [m for m in found if m not in used_macs]
+            return JSONResponse({"macs": new_macs, "scanned": True})
+        except Exception:
+            # Non-Pi or scan not supported — return empty list with hint
+            return JSONResponse({"macs": [], "scanned": False, "hint": "Enter MAC manually"})
+
+    @router.post("/api/commissioning/test-pump")
+    async def commissioning_test_pump(
+        gpio: int = Form(...),
+        duration: int = Form(default=3),
+    ) -> JSONResponse:
+        from flora.actuators.pump import water_plant as _pump
+        duration = max(1, min(5, duration))
+        success = await _pump(gpio, duration)
+        return JSONResponse({"ok": success, "gpio": gpio, "duration": duration})
+
+    @router.post("/plants/new")
+    async def commissioning_save(
+        name: str = Form(...),
+        species: str = Form(...),
+        sensor_mac: str = Form(...),
+        pump_gpio: int = Form(...),
+        moisture_target_min: int = Form(default=40),
+        moisture_target_max: int = Form(default=70),
+    ) -> RedirectResponse:
+        plant = {
+            "name": name.strip(),
+            "species": species.strip(),
+            "sensor_mac": sensor_mac.strip().upper(),
+            "pump_gpio": pump_gpio,
+            "moisture_target_min": moisture_target_min,
+            "moisture_target_max": moisture_target_max,
+        }
+        append_plant_to_toml(Path("flora.toml"), plant)
+        return RedirectResponse(url=f"/plants/{name.strip()}", status_code=303)
 
     @router.get("/logs", response_class=HTMLResponse)
     async def logs_page(request: Request) -> HTMLResponse:

--- a/src/flora/dashboard/templates/commissioning.html
+++ b/src/flora/dashboard/templates/commissioning.html
@@ -1,0 +1,246 @@
+{% extends "base.html" %}
+{% block content %}
+
+<div class="fade-up" style="margin-bottom: 1.5rem;">
+    <a href="/" style="font-family: 'JetBrains Mono', monospace; font-size: 0.65rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); text-decoration: none; transition: color 0.2s;" onmouseover="this.style.color='var(--accent)'" onmouseout="this.style.color='var(--text-dim)'">
+        ← All plants
+    </a>
+</div>
+
+<div class="page-header fade-up-1">
+    <div class="page-eyebrow">New Plant</div>
+    <h1 class="page-title"><em>Commission</em> a plant</h1>
+</div>
+
+<!-- Step indicators -->
+<div class="fade-up-2" style="display: flex; gap: 0; margin-bottom: 2.5rem; border: 1px solid var(--border); border-radius: 10px; overflow: hidden;">
+    {% for label in ["1. Sensor", "2. Configure", "3. Test pump", "4. Save"] %}
+    <div id="step-indicator-{{ loop.index }}" style="flex: 1; padding: 0.6rem 0.5rem; text-align: center; font-family: 'JetBrains Mono', monospace; font-size: 0.6rem; letter-spacing: 0.1em; text-transform: uppercase; color: {% if loop.first %}var(--accent){% else %}var(--text-dim){% endif %}; background: {% if loop.first %}rgba(0,224,122,0.06){% else %}transparent{% endif %}; border-right: {% if not loop.last %}1px solid var(--border){% else %}none{% endif %}; transition: all 0.3s;">
+        {{ label }}
+    </div>
+    {% endfor %}
+</div>
+
+<!-- Step 1: Scan -->
+<div id="step-1" class="card fade-up-3" style="margin-bottom: 1.25rem;">
+    <div class="card-label">Step 1 — Find your Mi Flora sensor</div>
+    <p style="font-size: 0.82rem; color: var(--text-muted); margin-bottom: 1.25rem;">
+        Power on the Mi Flora sensor and hold it within 1 metre of the Pi, then click Scan.
+        On dev machines (non-Pi) enter the MAC manually.
+    </p>
+    <div style="display: flex; gap: 0.75rem; align-items: flex-start; flex-wrap: wrap;">
+        <button type="button" class="btn btn-primary" onclick="scanSensors()" id="scanBtn">
+            Scan for sensors
+        </button>
+        <div id="scan-result" style="flex: 1; min-width: 200px;"></div>
+    </div>
+    <div style="margin-top: 1.25rem;">
+        <label style="font-size: 0.75rem; color: var(--text-muted); display: block; margin-bottom: 0.4rem;">Sensor MAC address</label>
+        <input type="text" id="sensor_mac" name="sensor_mac" placeholder="AA:BB:CC:DD:EE:FF"
+               style="width: 100%; max-width: 260px; background: var(--surface2); border: 1px solid var(--border); border-radius: 6px; color: var(--text); font-family: 'JetBrains Mono', monospace; font-size: 0.82rem; padding: 0.5rem 0.75rem; outline: none;"
+               oninput="this.value = this.value.toUpperCase()">
+    </div>
+    <div style="margin-top: 1.25rem; text-align: right;">
+        <button type="button" class="btn btn-primary" onclick="goToStep(2)">Next →</button>
+    </div>
+</div>
+
+<!-- Step 2: Configure -->
+<div id="step-2" class="card fade-up-3" style="margin-bottom: 1.25rem; display: none;">
+    <div class="card-label">Step 2 — Plant details</div>
+    <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 1rem; margin-bottom: 1.25rem;">
+
+        <div>
+            <label style="font-size: 0.75rem; color: var(--text-muted); display: block; margin-bottom: 0.4rem;">Plant name</label>
+            <input type="text" id="name" placeholder="basil-1" style="width: 100%; background: var(--surface2); border: 1px solid var(--border); border-radius: 6px; color: var(--text); font-family: 'JetBrains Mono', monospace; font-size: 0.82rem; padding: 0.5rem 0.75rem; outline: none;">
+            <div style="font-size: 0.65rem; color: var(--text-dim); margin-top: 0.3rem;">Unique identifier, no spaces</div>
+        </div>
+
+        <div>
+            <label style="font-size: 0.75rem; color: var(--text-muted); display: block; margin-bottom: 0.4rem;">Species</label>
+            <select id="species" style="width: 100%; background: var(--surface2); border: 1px solid var(--border); border-radius: 6px; color: var(--text); font-size: 0.82rem; padding: 0.5rem 0.75rem; outline: none;">
+                <option value="basil">Basil</option>
+                <option value="mint">Mint</option>
+                <option value="parsley">Parsley</option>
+                <option value="chives">Chives</option>
+                <option value="coriander">Coriander</option>
+                <option value="other">Other</option>
+            </select>
+        </div>
+
+        <div>
+            <label style="font-size: 0.75rem; color: var(--text-muted); display: block; margin-bottom: 0.4rem;">Pump GPIO pin</label>
+            <select id="pump_gpio" style="width: 100%; background: var(--surface2); border: 1px solid var(--border); border-radius: 6px; color: var(--text); font-size: 0.82rem; padding: 0.5rem 0.75rem; outline: none;">
+                {% for pin in free_gpio %}
+                <option value="{{ pin }}">GPIO {{ pin }}</option>
+                {% else %}
+                <option disabled>No free pins</option>
+                {% endfor %}
+            </select>
+        </div>
+
+        <div>
+            <label style="font-size: 0.75rem; color: var(--text-muted); display: block; margin-bottom: 0.4rem;">Moisture target min %</label>
+            <input type="number" id="moisture_min" value="40" min="0" max="100" style="width: 100%; background: var(--surface2); border: 1px solid var(--border); border-radius: 6px; color: var(--text); font-family: 'JetBrains Mono', monospace; font-size: 0.82rem; padding: 0.5rem 0.75rem; outline: none;">
+        </div>
+
+        <div>
+            <label style="font-size: 0.75rem; color: var(--text-muted); display: block; margin-bottom: 0.4rem;">Moisture target max %</label>
+            <input type="number" id="moisture_max" value="70" min="0" max="100" style="width: 100%; background: var(--surface2); border: 1px solid var(--border); border-radius: 6px; color: var(--text); font-family: 'JetBrains Mono', monospace; font-size: 0.82rem; padding: 0.5rem 0.75rem; outline: none;">
+        </div>
+    </div>
+    <div style="display: flex; justify-content: space-between;">
+        <button type="button" class="btn" onclick="goToStep(1)">← Back</button>
+        <button type="button" class="btn btn-primary" onclick="goToStep(3)">Next →</button>
+    </div>
+</div>
+
+<!-- Step 3: Test pump -->
+<div id="step-3" class="card fade-up-3" style="margin-bottom: 1.25rem; display: none;">
+    <div class="card-label">Step 3 — Test the pump</div>
+    <p style="font-size: 0.82rem; color: var(--text-muted); margin-bottom: 1.25rem;">
+        Ensure the pump tube is in a cup of water before testing. This fires the relay for 3 seconds.
+    </p>
+    <div style="display: flex; gap: 0.75rem; align-items: center; flex-wrap: wrap;">
+        <button type="button" class="btn btn-primary" onclick="testPump()">Fire pump (3s)</button>
+        <span id="pump-result" style="font-size: 0.8rem;"></span>
+    </div>
+    <div style="margin-top: 1.25rem; display: flex; justify-content: space-between;">
+        <button type="button" class="btn" onclick="goToStep(2)">← Back</button>
+        <button type="button" class="btn btn-primary" onclick="goToStep(4)">Next →</button>
+    </div>
+</div>
+
+<!-- Step 4: Confirm & save -->
+<div id="step-4" style="display: none;">
+    <div class="card fade-up-3" style="margin-bottom: 1.25rem;">
+        <div class="card-label">Step 4 — Confirm &amp; save</div>
+        <div id="summary" style="margin-bottom: 1.5rem;"></div>
+        <div style="background: rgba(255,186,74,0.06); border: 1px solid rgba(255,186,74,0.18); border-radius: 8px; padding: 0.75rem 1rem; font-size: 0.78rem; color: var(--amber); margin-bottom: 1.25rem;">
+            After saving, restart Flora to activate the new plant.
+        </div>
+        <div style="display: flex; justify-content: space-between;">
+            <button type="button" class="btn" onclick="goToStep(3)">← Back</button>
+            <form method="post" action="/plants/new" id="saveForm" style="display: inline;">
+                <input type="hidden" name="name" id="f_name">
+                <input type="hidden" name="species" id="f_species">
+                <input type="hidden" name="sensor_mac" id="f_mac">
+                <input type="hidden" name="pump_gpio" id="f_gpio">
+                <input type="hidden" name="moisture_target_min" id="f_min">
+                <input type="hidden" name="moisture_target_max" id="f_max">
+                <button type="submit" class="btn btn-primary">Save plant</button>
+            </form>
+        </div>
+    </div>
+</div>
+
+<script>
+function goToStep(n) {
+    [1,2,3,4].forEach(function(i) {
+        var el = document.getElementById('step-' + i);
+        if (el) el.style.display = i === n ? '' : 'none';
+        var ind = document.getElementById('step-indicator-' + i);
+        if (ind) {
+            ind.style.color = i === n ? 'var(--accent)' : 'var(--text-dim)';
+            ind.style.background = i === n ? 'rgba(0,224,122,0.06)' : 'transparent';
+        }
+    });
+    if (n === 4) buildSummary();
+}
+
+async function scanSensors() {
+    var btn = document.getElementById('scanBtn');
+    var result = document.getElementById('scan-result');
+    btn.textContent = 'Scanning\u2026';
+    btn.disabled = true;
+    result.textContent = '';
+    try {
+        var resp = await fetch('/api/commissioning/scan');
+        var data = await resp.json();
+        if (data.macs && data.macs.length > 0) {
+            data.macs.forEach(function(mac) {
+                var b = document.createElement('button');
+                b.type = 'button';
+                b.className = 'btn';
+                b.style.cssText = 'font-size:0.72rem;margin:0.25rem;';
+                b.textContent = mac;
+                b.addEventListener('click', function() {
+                    document.getElementById('sensor_mac').value = mac;
+                });
+                result.appendChild(b);
+            });
+        } else {
+            var hint = document.createElement('span');
+            hint.style.cssText = 'font-size:0.75rem;color:var(--text-dim);';
+            hint.textContent = data.hint || 'No sensors found \u2014 enter MAC manually';
+            result.appendChild(hint);
+        }
+    } catch(e) {
+        var err = document.createElement('span');
+        err.style.cssText = 'font-size:0.75rem;color:var(--red);';
+        err.textContent = 'Scan failed \u2014 enter MAC manually';
+        result.appendChild(err);
+    }
+    btn.textContent = 'Scan for sensors';
+    btn.disabled = false;
+}
+
+async function testPump() {
+    var gpio = document.getElementById('pump_gpio').value;
+    var result = document.getElementById('pump-result');
+    result.style.color = 'var(--text-dim)';
+    result.textContent = 'Firing\u2026';
+    try {
+        var fd = new FormData();
+        fd.append('gpio', gpio);
+        fd.append('duration', '3');
+        var resp = await fetch('/api/commissioning/test-pump', { method: 'POST', body: fd });
+        var data = await resp.json();
+        result.style.color = data.ok ? 'var(--accent)' : 'var(--red)';
+        result.textContent = data.ok ? 'Pump fired OK' : 'Pump failed \u2014 check wiring';
+    } catch(e) {
+        result.style.color = 'var(--red)';
+        result.textContent = 'Request failed';
+    }
+}
+
+function makeRow(label, value) {
+    var row = document.createElement('div');
+    row.className = 'stat-row';
+    var lbl = document.createElement('span');
+    lbl.className = 'stat-label';
+    lbl.textContent = label;
+    var val = document.createElement('span');
+    val.className = 'stat-value';
+    val.textContent = value;
+    row.appendChild(lbl);
+    row.appendChild(val);
+    return row;
+}
+
+function buildSummary() {
+    var name    = document.getElementById('name').value;
+    var species = document.getElementById('species').value;
+    var mac     = document.getElementById('sensor_mac').value;
+    var gpio    = document.getElementById('pump_gpio').value;
+    var min     = document.getElementById('moisture_min').value;
+    var max     = document.getElementById('moisture_max').value;
+
+    var summary = document.getElementById('summary');
+    summary.textContent = '';
+    summary.appendChild(makeRow('Name', name));
+    summary.appendChild(makeRow('Species', species));
+    summary.appendChild(makeRow('Sensor MAC', mac));
+    summary.appendChild(makeRow('Pump GPIO', 'GPIO ' + gpio));
+    summary.appendChild(makeRow('Moisture target', min + '% \u2013 ' + max + '%'));
+
+    document.getElementById('f_name').value    = name;
+    document.getElementById('f_species').value = species;
+    document.getElementById('f_mac').value     = mac;
+    document.getElementById('f_gpio').value    = gpio;
+    document.getElementById('f_min').value     = min;
+    document.getElementById('f_max').value     = max;
+}
+</script>
+
+{% endblock %}

--- a/tests/test_commissioning.py
+++ b/tests/test_commissioning.py
@@ -1,0 +1,121 @@
+"""Tests for plant commissioning wizard (issue #25)."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from flora.config import PlantConfig, append_plant_to_toml
+
+
+# ---------------------------------------------------------------------------
+# append_plant_to_toml
+# ---------------------------------------------------------------------------
+
+def test_append_plant_to_toml_creates_file_if_missing(tmp_path):
+    toml_path = tmp_path / "flora.toml"
+    append_plant_to_toml(toml_path, {"name": "basil-1", "species": "basil", "pump_gpio": 17})
+    content = toml_path.read_text()
+    assert "[[plants]]" in content
+    assert 'name = "basil-1"' in content
+    assert "pump_gpio = 17" in content
+
+
+def test_append_plant_to_toml_preserves_existing_content(tmp_path):
+    toml_path = tmp_path / "flora.toml"
+    toml_path.write_text('[app]\ndb_path = "flora.db"\n\n[[plants]]\nname = "mint-1"\n')
+    append_plant_to_toml(toml_path, {"name": "basil-1", "species": "basil", "pump_gpio": 17})
+    content = toml_path.read_text()
+    assert 'name = "mint-1"' in content
+    assert 'name = "basil-1"' in content
+    assert 'db_path = "flora.db"' in content
+
+
+def test_append_plant_to_toml_skips_none_values(tmp_path):
+    toml_path = tmp_path / "flora.toml"
+    append_plant_to_toml(toml_path, {"name": "basil-1", "auto_water_if_below": None, "pump_gpio": 17})
+    content = toml_path.read_text()
+    assert "auto_water_if_below" not in content
+    assert "pump_gpio = 17" in content
+
+
+# ---------------------------------------------------------------------------
+# Dashboard routes
+# ---------------------------------------------------------------------------
+
+def _make_app():
+    from fastapi import FastAPI
+    from fastapi.templating import Jinja2Templates
+    from pathlib import Path as P
+    from flora.dashboard.routes import create_router
+
+    plant = PlantConfig(
+        name="mint", species="mint",
+        sensor_mac="AA:BB:CC:DD:EE:01", pump_gpio=18,
+    )
+    config = MagicMock()
+    config.plants = [plant]
+    db = MagicMock()
+
+    templates_dir = P(__file__).parent.parent / "src" / "flora" / "dashboard" / "templates"
+    templates = Jinja2Templates(directory=str(templates_dir))
+
+    app = FastAPI()
+    app.include_router(create_router(config, db, templates))
+    return app
+
+
+def test_commissioning_page_renders():
+    client = TestClient(_make_app())
+    resp = client.get("/plants/new")
+    assert resp.status_code == 200
+    assert "Commission" in resp.text
+    assert "sensor_mac" in resp.text
+
+
+def test_commissioning_page_excludes_used_gpio():
+    """GPIO 18 is used by mint — should not appear in the free pin selector."""
+    client = TestClient(_make_app())
+    resp = client.get("/plants/new")
+    assert resp.status_code == 200
+    # GPIO 18 is used by the existing plant — must not appear as an option
+    assert "GPIO 18" not in resp.text
+
+
+async def test_commissioning_test_pump_calls_actuator():
+    app = _make_app()
+    client = TestClient(app)
+    with patch("flora.actuators.pump.water_plant", new=AsyncMock(return_value=True)):
+        resp = client.post("/api/commissioning/test-pump", data={"gpio": "22", "duration": "3"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["gpio"] == 22
+
+
+async def test_commissioning_save_appends_to_toml(tmp_path):
+    toml_path = tmp_path / "flora.toml"
+    toml_path.write_text('[app]\ndb_path = "flora.db"\n')
+
+    app = _make_app()
+    client = TestClient(app, follow_redirects=False)
+
+    with patch("flora.dashboard.routes.append_plant_to_toml") as mock_append, \
+         patch("flora.dashboard.routes.Path", return_value=toml_path):
+        resp = client.post("/plants/new", data={
+            "name": "basil-2",
+            "species": "basil",
+            "sensor_mac": "CC:DD:EE:FF:00:11",
+            "pump_gpio": "22",
+            "moisture_target_min": "40",
+            "moisture_target_max": "70",
+        })
+
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/plants/basil-2"
+    mock_append.assert_called_once()
+    saved = mock_append.call_args[0][1]
+    assert saved["name"] == "basil-2"
+    assert saved["sensor_mac"] == "CC:DD:EE:FF:00:11"


### PR DESCRIPTION
Closes #25

## Summary
4-step wizard at `/plants/new` replaces manual `flora.toml` editing:
1. **Scan** — BLE scan for unassigned Mi Flora sensors; manual MAC entry fallback
2. **Configure** — name, species dropdown, free GPIO pin selector, moisture targets
3. **Test pump** — fires relay 3s via `/api/commissioning/test-pump`
4. **Save** — POSTs to `/plants/new`, calls `append_plant_to_toml`, redirects to plant page

`append_plant_to_toml(path, plant_dict)` appends a `[[plants]]` TOML block, preserving all existing content and skipping `None` values.

All dynamic content rendered with `textContent`/`createElement` — no `innerHTML` with user data (XSS safe).

`/plants/new` registered before `/plants/{name}` to prevent wildcard match.

## Tests (7 new in `tests/test_commissioning.py`)
- `append_plant_to_toml`: creates file, preserves existing, skips None
- GET `/plants/new` renders correctly; GPIO 18 (used by existing plant) excluded
- POST `/api/commissioning/test-pump` calls pump actuator
- POST `/plants/new` calls `append_plant_to_toml` and redirects

🤖 Generated with [Claude Code](https://claude.com/claude-code)