### PR TITLE
Dashboard: add + Plant nav link and Add plant button to overview

### DIFF
--- a/src/flora/dashboard/templates/base.html
+++ b/src/flora/dashboard/templates/base.html
@@ -619,6 +619,7 @@
             <a href="/" class="nav-link {% if request.url.path == '/' %}active{% endif %}">Overview</a>
             <a href="/actions" class="nav-link {% if '/actions' in request.url.path %}active{% endif %}">Actions</a>
             <a href="/logs" class="nav-link {% if '/logs' in request.url.path %}active{% endif %}">Journal</a>
+            <a href="/plants/new" class="nav-link {% if request.url.path == '/plants/new' %}active{% endif %}">+ Plant</a>
         </div>
         <div class="nav-spacer"></div>
         <div class="nav-badge">

--- a/src/flora/dashboard/templates/index.html
+++ b/src/flora/dashboard/templates/index.html
@@ -1,9 +1,12 @@
 {% extends "base.html" %}
 {% block content %}
 
-<div class="page-header fade-up">
-    <div class="page-eyebrow">Garden Intelligence</div>
-    <h1 class="page-title"><em>Flora</em> Overview</h1>
+<div class="page-header fade-up" style="display:flex; align-items:flex-start; justify-content:space-between; flex-wrap:wrap; gap:1rem;">
+    <div>
+        <div class="page-eyebrow">Garden Intelligence</div>
+        <h1 class="page-title"><em>Flora</em> Overview</h1>
+    </div>
+    <a href="/plants/new" class="btn" style="margin-top:0.5rem;">+ Add plant</a>
 </div>
 
 <!-- Botanical art canvas — p5.js generative plant visualization -->


### PR DESCRIPTION
## Summary
- Adds `+ Plant` nav link to the global nav bar in `base.html` (highlights active when on `/plants/new`)
- Adds `+ Add plant` ghost button to the overview page header in `index.html`, right-aligned alongside the page title

## Test plan
- [ ] Visit overview page — confirm `+ Add plant` button appears top-right of page header
- [ ] Click button — confirm navigation to commissioning wizard
- [ ] Check nav bar — confirm `+ Plant` link is present and highlights when on `/plants/new`
- [ ] All unit tests pass (`pytest`)

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)