### PR TITLE
Agent: detect watering-ineffective pattern and escalate via Telegram

### DIFF
--- a/src/flora/agent/watchers.py
+++ b/src/flora/agent/watchers.py
@@ -1,0 +1,47 @@
+"""Watchers that detect abnormal plant patterns and trigger escalations."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from flora.config import PlantConfig
+from flora.db import Database
+
+
+async def check_watering_effectiveness(
+    db: Database,
+    plant: PlantConfig,
+    hours: int = 6,
+    min_firings: int = 3,
+) -> tuple[bool, int, float | None]:
+    """Check whether auto-watering is having no effect.
+
+    Returns (ineffective, count, current_moisture):
+    - ineffective=True means min_firings+ auto_waters occurred in the window but
+      moisture did not improve by >= 5 percentage points.
+    - count is the number of auto_water actions found in the window.
+    - current_moisture is the latest sensor reading (None if unavailable).
+    """
+    count = await db.count_recent_same_action(plant.name, "auto_water", hours=hours)
+    if count < min_firings:
+        return False, count, None
+
+    cutoff = datetime.utcnow() - timedelta(hours=hours)
+    actions = await db.get_recent_actions(limit=200, plant_name=plant.name)
+    auto_waters = [
+        a for a in actions
+        if a.action_type == "auto_water" and a.timestamp >= cutoff
+    ]
+    if not auto_waters:
+        return False, count, None
+
+    earliest = min(auto_waters, key=lambda a: a.timestamp)
+    moisture_before = earliest.parameters.get("moisture")
+
+    latest = await db.get_latest_sensor_reading(plant.name)
+    if latest is None or latest.moisture is None:
+        return False, count, None
+
+    current = latest.moisture
+    baseline = moisture_before if moisture_before is not None else (plant.auto_water_if_below or 0.0)
+    ineffective = (current - baseline) < 5.0
+    return ineffective, count, current

--- a/src/flora/scheduler.py
+++ b/src/flora/scheduler.py
@@ -14,7 +14,8 @@ from flora.sensors.sht31 import read_sht31
 from flora.sensors.bh1750 import read_bh1750
 
 from flora.agent.loop import AgentLoop
-from flora.notifications import send_daily_summary
+from flora.agent.watchers import check_watering_effectiveness
+from flora.notifications import send_daily_summary, send_telegram
 from flora.sensors.camera import capture_photo
 
 logger = logging.getLogger(__name__)
@@ -60,6 +61,30 @@ async def _poll_sensors(config: AppConfig, db: Database) -> None:
                 reasoning=f"Auto-water rule: moisture {reading.moisture:.1f}% < {threshold}%",
                 claude_model="rule",
             ))
+
+        # Watering-effectiveness watcher — only relevant for plants with auto-water
+        if plant.auto_water_if_below is not None:
+            ineffective, fire_count, current_moisture = await check_watering_effectiveness(db, plant)
+            if ineffective:
+                cooldown = await db.count_recent_same_action(plant.name, "pump_alert", hours=12)
+                if cooldown == 0:
+                    msg = (
+                        f"Plant {plant.name}: pump fired {fire_count}\u00d7 in 6h but moisture "
+                        f"unchanged ({current_moisture:.0f}%). Check reservoir/pump."
+                    )
+                    await send_telegram(config.telegram_token, config.telegram_chat_id, msg)
+                    await db.log_action(ActionRecord(
+                        plant_name=plant.name,
+                        timestamp=now,
+                        action_type="pump_alert",
+                        parameters={"count": fire_count, "moisture": current_moisture},
+                        reasoning="Auto-watering ineffective — escalated via Telegram",
+                        claude_model="rule",
+                    ))
+                    logger.warning(
+                        "Pump ineffective for %s (%d firings, moisture=%.0f%%)",
+                        plant.name, fire_count, current_moisture,
+                    )
 
     # Poll ambient sensors
     sht31 = await read_sht31()

--- a/tests/test_auto_water.py
+++ b/tests/test_auto_water.py
@@ -65,6 +65,7 @@ async def test_auto_water_triggers_when_below_threshold():
     db.insert_sensor_reading = AsyncMock()
     db.log_action = AsyncMock()
     db.insert_ambient_reading = AsyncMock()
+    db.count_recent_same_action = AsyncMock(return_value=0)  # watcher: no recent firings
 
     miflora_reading = _make_miflora_reading(moisture=18.0)
 
@@ -91,6 +92,7 @@ async def test_auto_water_not_triggered_when_above_threshold():
     db.insert_sensor_reading = AsyncMock()
     db.log_action = AsyncMock()
     db.insert_ambient_reading = AsyncMock()
+    db.count_recent_same_action = AsyncMock(return_value=0)  # watcher: no recent firings
 
     miflora_reading = _make_miflora_reading(moisture=40.0)
 
@@ -134,6 +136,7 @@ async def test_auto_water_duration_clamped_to_5_30():
     db.insert_sensor_reading = AsyncMock()
     db.log_action = AsyncMock()
     db.insert_ambient_reading = AsyncMock()
+    db.count_recent_same_action = AsyncMock(return_value=0)  # watcher: no recent firings
 
     miflora_reading = _make_miflora_reading(moisture=10.0)
 

--- a/tests/test_watering_watcher.py
+++ b/tests/test_watering_watcher.py
@@ -1,0 +1,145 @@
+"""Tests for the watering-effectiveness watcher (issue #30)."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from flora.agent.watchers import check_watering_effectiveness
+from flora.config import PlantConfig
+from flora.db import ActionRecord, SensorReading
+
+
+def _plant(auto_water_if_below: int = 30) -> PlantConfig:
+    return PlantConfig(
+        name="basil",
+        species="basil",
+        sensor_mac="AA:BB:CC:DD:EE:01",
+        pump_gpio=17,
+        auto_water_if_below=auto_water_if_below,
+    )
+
+
+def _action(moisture: float, minutes_ago: int) -> ActionRecord:
+    return ActionRecord(
+        plant_name="basil",
+        timestamp=datetime.utcnow() - timedelta(minutes=minutes_ago),
+        action_type="auto_water",
+        parameters={"moisture": moisture, "duration_seconds": 8, "threshold": 30},
+        reasoning="Auto-water rule",
+        claude_model="rule",
+    )
+
+
+def _reading(moisture: float) -> SensorReading:
+    return SensorReading(
+        plant_name="basil",
+        timestamp=datetime.utcnow(),
+        moisture=moisture,
+        temperature=22.0,
+        light=None,
+        fertility=None,
+        battery=None,
+    )
+
+
+async def test_returns_true_when_3_auto_waters_no_moisture_change():
+    db = MagicMock()
+    db.count_recent_same_action = AsyncMock(return_value=3)
+    db.get_recent_actions = AsyncMock(return_value=[
+        _action(moisture=25.0, minutes_ago=300),
+        _action(moisture=25.0, minutes_ago=180),
+        _action(moisture=25.0, minutes_ago=60),
+    ])
+    db.get_latest_sensor_reading = AsyncMock(return_value=_reading(25.5))
+
+    ineffective, count, moisture = await check_watering_effectiveness(db, _plant())
+
+    assert ineffective is True
+    assert count == 3
+    assert moisture == pytest.approx(25.5)
+
+
+async def test_returns_false_when_moisture_improved():
+    db = MagicMock()
+    db.count_recent_same_action = AsyncMock(return_value=3)
+    db.get_recent_actions = AsyncMock(return_value=[
+        _action(moisture=25.0, minutes_ago=300),
+        _action(moisture=25.0, minutes_ago=180),
+        _action(moisture=25.0, minutes_ago=60),
+    ])
+    # Moisture improved by 10 points
+    db.get_latest_sensor_reading = AsyncMock(return_value=_reading(35.0))
+
+    ineffective, count, moisture = await check_watering_effectiveness(db, _plant())
+
+    assert ineffective is False
+    assert count == 3
+    assert moisture == pytest.approx(35.0)
+
+
+async def test_returns_false_fewer_than_min_firings():
+    db = MagicMock()
+    db.count_recent_same_action = AsyncMock(return_value=2)
+
+    ineffective, count, moisture = await check_watering_effectiveness(db, _plant())
+
+    assert ineffective is False
+    assert count == 2
+    assert moisture is None
+    db.get_recent_actions.assert_not_called()
+
+
+async def test_returns_false_no_latest_reading():
+    db = MagicMock()
+    db.count_recent_same_action = AsyncMock(return_value=3)
+    db.get_recent_actions = AsyncMock(return_value=[
+        _action(moisture=25.0, minutes_ago=300),
+        _action(moisture=25.0, minutes_ago=180),
+        _action(moisture=25.0, minutes_ago=60),
+    ])
+    db.get_latest_sensor_reading = AsyncMock(return_value=None)
+
+    ineffective, count, moisture = await check_watering_effectiveness(db, _plant())
+
+    assert ineffective is False
+    assert count == 3
+    assert moisture is None
+
+
+async def test_returns_false_when_actions_outside_window():
+    """Actions older than the hours window should not be counted."""
+    db = MagicMock()
+    # count_recent_same_action already filters by hours, but get_recent_actions
+    # returns all — watcher filters them by timestamp.
+    db.count_recent_same_action = AsyncMock(return_value=3)
+    # All actions are >6h old — watcher should filter them out
+    db.get_recent_actions = AsyncMock(return_value=[
+        _action(moisture=25.0, minutes_ago=400),
+        _action(moisture=25.0, minutes_ago=420),
+        _action(moisture=25.0, minutes_ago=440),
+    ])
+    db.get_latest_sensor_reading = AsyncMock(return_value=_reading(25.0))
+
+    ineffective, count, moisture = await check_watering_effectiveness(db, _plant())
+
+    # auto_waters list is empty after window filter → returns False
+    assert ineffective is False
+
+
+async def test_exactly_5_point_improvement_is_not_ineffective():
+    """Exactly 5% improvement is the boundary — should be effective (not ineffective)."""
+    db = MagicMock()
+    db.count_recent_same_action = AsyncMock(return_value=3)
+    db.get_recent_actions = AsyncMock(return_value=[
+        _action(moisture=25.0, minutes_ago=300),
+        _action(moisture=25.0, minutes_ago=180),
+        _action(moisture=25.0, minutes_ago=60),
+    ])
+    db.get_latest_sensor_reading = AsyncMock(return_value=_reading(30.0))
+
+    ineffective, count, moisture = await check_watering_effectiveness(db, _plant())
+
+    # 30.0 - 25.0 = 5.0, not < 5.0 → effective
+    assert ineffective is False


### PR DESCRIPTION
## Summary
- Adds `src/flora/agent/watchers.py` with `check_watering_effectiveness(db, plant, hours=6, min_firings=3)` — returns `(ineffective, count, current_moisture)`
- Integrates watcher into `_poll_sensors` in `scheduler.py`: after each reading, if the plant has `auto_water_if_below` set, checks for 3+ auto_waters in 6h with < 5% moisture improvement
- On ineffective detection: sends Telegram alert and logs a `pump_alert` action (12h cooldown via action log)
- Fixes `test_auto_water.py` mocks to include `count_recent_same_action` as `AsyncMock(return_value=0)` so the watcher exits early in those tests

## Test plan
- [ ] `pytest tests/test_watering_watcher.py -v` — 6 tests covering: ineffective detection, moisture improved, fewer than min_firings, no readings, actions outside window, boundary (exactly 5%)
- [ ] `pytest tests/test_auto_water.py -v` — existing auto_water tests still pass
- [ ] Full suite: `pytest tests/ -q --ignore=tests/test_dashboard_e2e.py`

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)