### PR TITLE
Config: validate flora.toml on load and report clear errors

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -1,12 +1,16 @@
 """TOML configuration loader for Flora."""
 from __future__ import annotations
 
+import re
+
 try:
     import tomllib
 except ImportError:
     import tomli as tomllib  # type: ignore[no-redef]
 from dataclasses import dataclass, field
 from pathlib import Path
+
+_MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$")
 
 
 @dataclass(frozen=True)
@@ -51,6 +55,58 @@ class AppConfig:
         return next((p for p in self.smart_plugs if p.role == role), None)
 
 
+def validate_config(raw: dict) -> list[str]:
+    """Validate raw TOML dict and return a list of human-readable error strings."""
+    errors: list[str] = []
+    plants = raw.get("plants", [])
+
+    seen_names: set[str] = set()
+    seen_macs: set[str] = set()
+    seen_gpios: set[int] = set()
+
+    for i, p in enumerate(plants):
+        label = f"Plant #{i + 1}"
+
+        # Required fields
+        for field_name in ("name", "species", "sensor_mac", "pump_gpio"):
+            if field_name not in p:
+                errors.append(f"{label}: missing required field '{field_name}'")
+
+        name = p.get("name")
+        if name is not None:
+            if name in seen_names:
+                errors.append(f"{label}: duplicate plant name '{name}'")
+            seen_names.add(name)
+            label = f"Plant '{name}'"
+
+        mac = p.get("sensor_mac")
+        if mac is not None:
+            if not _MAC_RE.match(mac):
+                errors.append(f"{label}: invalid sensor_mac '{mac}' (expected XX:XX:XX:XX:XX:XX)")
+            elif mac.upper() in seen_macs:
+                errors.append(f"{label}: duplicate sensor_mac '{mac}'")
+            else:
+                seen_macs.add(mac.upper())
+
+        gpio = p.get("pump_gpio")
+        if gpio is not None:
+            if not isinstance(gpio, int) or not (0 <= gpio <= 27):
+                errors.append(f"{label}: pump_gpio must be an integer 0-27 (got {gpio!r})")
+            elif gpio in seen_gpios:
+                errors.append(f"{label}: duplicate pump_gpio {gpio}")
+            else:
+                seen_gpios.add(gpio)
+
+        mn = p.get("moisture_target_min")
+        mx = p.get("moisture_target_max")
+        if mn is not None and mx is not None and mn >= mx:
+            errors.append(
+                f"{label}: moisture_target_min ({mn}) must be less than moisture_target_max ({mx})"
+            )
+
+    return errors
+
+
 def append_plant_to_toml(path: str | Path, plant: dict) -> None:
     """Append a new [[plants]] entry to flora.toml, preserving all existing content."""
     config_path = Path(path)
@@ -75,6 +131,10 @@ def load_config(path: str | Path = "flora.toml") -> AppConfig:
 
     with open(config_path, "rb") as f:
         raw = tomllib.load(f)
+
+    errors = validate_config(raw)
+    if errors:
+        raise ValueError("flora.toml validation failed:\n" + "\n".join(errors))
 
     app_section = raw.get("app", {})
     anthropic_section = raw.get("anthropic", {})

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,145 @@
+"""Tests for flora.toml config validation (issue #31)."""
+from __future__ import annotations
+
+import pytest
+
+from flora.config import validate_config
+
+
+def _base_plant(**overrides) -> dict:
+    p = {
+        "name": "basil",
+        "species": "basil",
+        "sensor_mac": "AA:BB:CC:DD:EE:01",
+        "pump_gpio": 17,
+        "moisture_target_min": 40,
+        "moisture_target_max": 70,
+    }
+    p.update(overrides)
+    return p
+
+
+def test_valid_config_returns_no_errors():
+    raw = {
+        "app": {"db_path": "flora.db"},
+        "plants": [_base_plant()],
+    }
+    assert validate_config(raw) == []
+
+
+def test_valid_config_multiple_plants_returns_no_errors():
+    raw = {
+        "plants": [
+            _base_plant(name="basil", sensor_mac="AA:BB:CC:DD:EE:01", pump_gpio=17),
+            _base_plant(name="mint",  sensor_mac="AA:BB:CC:DD:EE:02", pump_gpio=18),
+        ]
+    }
+    assert validate_config(raw) == []
+
+
+def test_duplicate_mac_detected():
+    raw = {
+        "plants": [
+            _base_plant(name="basil", sensor_mac="AA:BB:CC:DD:EE:01", pump_gpio=17),
+            _base_plant(name="mint",  sensor_mac="AA:BB:CC:DD:EE:01", pump_gpio=18),
+        ]
+    }
+    errors = validate_config(raw)
+    assert any("duplicate sensor_mac" in e for e in errors)
+
+
+def test_duplicate_gpio_detected():
+    raw = {
+        "plants": [
+            _base_plant(name="basil", sensor_mac="AA:BB:CC:DD:EE:01", pump_gpio=17),
+            _base_plant(name="mint",  sensor_mac="AA:BB:CC:DD:EE:02", pump_gpio=17),
+        ]
+    }
+    errors = validate_config(raw)
+    assert any("duplicate pump_gpio" in e for e in errors)
+
+
+def test_duplicate_name_detected():
+    raw = {
+        "plants": [
+            _base_plant(name="basil", sensor_mac="AA:BB:CC:DD:EE:01", pump_gpio=17),
+            _base_plant(name="basil", sensor_mac="AA:BB:CC:DD:EE:02", pump_gpio=18),
+        ]
+    }
+    errors = validate_config(raw)
+    assert any("duplicate plant name" in e for e in errors)
+
+
+def test_invalid_mac_format_detected():
+    raw = {"plants": [_base_plant(sensor_mac="ZZZZ")]}
+    errors = validate_config(raw)
+    assert any("invalid sensor_mac" in e for e in errors)
+
+
+def test_mac_case_insensitive_dedup():
+    """AA:BB:CC:DD:EE:01 and aa:bb:cc:dd:ee:01 are the same MAC."""
+    raw = {
+        "plants": [
+            _base_plant(name="basil", sensor_mac="AA:BB:CC:DD:EE:01", pump_gpio=17),
+            _base_plant(name="mint",  sensor_mac="aa:bb:cc:dd:ee:01", pump_gpio=18),
+        ]
+    }
+    errors = validate_config(raw)
+    assert any("duplicate sensor_mac" in e for e in errors)
+
+
+def test_moisture_min_gte_max_detected():
+    raw = {"plants": [_base_plant(moisture_target_min=70, moisture_target_max=40)]}
+    errors = validate_config(raw)
+    assert any("moisture_target_min" in e for e in errors)
+
+
+def test_moisture_min_equal_max_detected():
+    raw = {"plants": [_base_plant(moisture_target_min=50, moisture_target_max=50)]}
+    errors = validate_config(raw)
+    assert any("moisture_target_min" in e for e in errors)
+
+
+def test_missing_required_field_detected():
+    raw = {"plants": [{"species": "basil", "sensor_mac": "AA:BB:CC:DD:EE:01", "pump_gpio": 17}]}
+    errors = validate_config(raw)
+    assert any("missing required field 'name'" in e for e in errors)
+
+
+def test_all_errors_returned_at_once():
+    """Multiple problems should all appear in the errors list simultaneously."""
+    raw = {
+        "plants": [
+            # missing name, invalid mac, gpio out of range
+            {"species": "basil", "sensor_mac": "BADMAC", "pump_gpio": 99},
+        ]
+    }
+    errors = validate_config(raw)
+    assert len(errors) >= 3
+
+
+def test_gpio_out_of_range_detected():
+    raw = {"plants": [_base_plant(pump_gpio=99)]}
+    errors = validate_config(raw)
+    assert any("pump_gpio" in e for e in errors)
+
+
+def test_empty_plants_list_is_valid():
+    raw = {"plants": []}
+    assert validate_config(raw) == []
+
+
+def test_load_config_raises_on_invalid(tmp_path):
+    """load_config raises ValueError with all errors when validation fails."""
+    from flora.config import load_config
+
+    toml = tmp_path / "flora.toml"
+    toml.write_text(
+        '[app]\ndb_path = "flora.db"\n'
+        '[anthropic]\napi_key = "sk-test"\n'
+        '[telegram]\ntoken = ""\nchat_id = ""\n'
+        '[[plants]]\nname = "basil"\nspecies = "basil"\n'
+        'sensor_mac = "BADMAC"\npump_gpio = 17\n'
+    )
+    with pytest.raises(ValueError, match="flora.toml validation failed"):
+        load_config(toml)


### PR DESCRIPTION
## Summary
- Adds `validate_config(raw: dict) -> list[str]` to `config.py` — checks required fields, MAC format, GPIO range (0-27), min < max moisture targets, and duplicate names/MACs/GPIOs across plants
- `load_config` now calls `validate_config` and raises `ValueError` with all errors joined by newline, so users see every problem at once rather than a cryptic KeyError at startup
- 14 unit tests in `tests/test_config_validation.py` covering all acceptance criteria

## Test plan
- [ ] `pytest tests/test_config_validation.py -v` — all 14 tests pass
- [ ] Full suite: `pytest tests/ -q --ignore=tests/test_dashboard_e2e.py`

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)