### PR TITLE
Dashboard: show stale-reading warning on plant cards

### DIFF
--- a/src/flora/dashboard/routes.py
+++ b/src/flora/dashboard/routes.py
@@ -12,7 +12,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Stre
 from fastapi.templating import Jinja2Templates
 
 from flora.config import AppConfig, append_plant_to_toml
-from flora.db import Database
+from flora.db import Database, SensorReading
 
 # GPIO pins commonly available on Pi for relay use (BCM numbering)
 _CANDIDATE_GPIO_PINS = [4, 17, 18, 22, 23, 24, 25, 27]
@@ -34,6 +34,7 @@ def create_router(
                 "config": plant,
                 "reading": reading,
                 "status": _status(reading.moisture if reading else None, plant.moisture_target_min, plant.moisture_target_max),
+                "reading_age_hours": _reading_age_hours(reading),
             })
         ambient = await db.get_latest_ambient()
         actions = await db.get_recent_actions(limit=5)
@@ -85,6 +86,7 @@ def create_router(
                 "journal": journal,
                 "actions": actions,
                 "status": _status(reading.moisture if reading else None, plant.moisture_target_min, plant.moisture_target_max),
+                "reading_age_hours": _reading_age_hours(reading),
             },
         )
 
@@ -253,6 +255,14 @@ def _mock_moisture(species: str) -> float:
 
 def _mock_status(species: str) -> str:
     return _SPECIES_MOCK.get(species.lower(), _DEFAULT_MOCK)[1]
+
+
+def _reading_age_hours(reading: SensorReading | None) -> float | None:
+    """Return how many hours old a reading is, or None if no reading."""
+    if reading is None:
+        return None
+    delta = datetime.utcnow() - reading.timestamp
+    return delta.total_seconds() / 3600
 
 
 def _status(moisture: float | None, target_min: int, target_max: int) -> str:

--- a/src/flora/dashboard/templates/index.html
+++ b/src/flora/dashboard/templates/index.html
@@ -199,7 +199,14 @@
                 {{ p.config.species }}
             </div>
         </div>
-        <span class="badge badge-{{ p.status }}">{{ p.status }}</span>
+        <div style="display:flex; gap:0.4rem; align-items:center; flex-wrap:wrap;">
+            <span class="badge badge-{{ p.status }}">{{ p.status }}</span>
+            {% if p.reading_age_hours is none %}
+            <span style="font-family:'JetBrains Mono',monospace;font-size:0.58rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--amber);background:rgba(255,186,74,0.1);border:1px solid rgba(255,186,74,0.25);border-radius:4px;padding:2px 6px;">No data</span>
+            {% elif p.reading_age_hours > 2 %}
+            <span style="font-family:'JetBrains Mono',monospace;font-size:0.58rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--amber);background:rgba(255,186,74,0.1);border:1px solid rgba(255,186,74,0.25);border-radius:4px;padding:2px 6px;">Stale ({{ "%.0f"|format(p.reading_age_hours) }}h)</span>
+            {% endif %}
+        </div>
     </div>
 
     <!-- Moisture ring + stats -->

--- a/src/flora/dashboard/templates/plant.html
+++ b/src/flora/dashboard/templates/plant.html
@@ -13,6 +13,11 @@
     <div style="display: flex; align-items: baseline; gap: 1.25rem; flex-wrap: wrap;">
         <h1 class="page-title"><em>{{ plant.name }}</em></h1>
         <span class="badge badge-{{ status }}" style="font-size: 0.7rem; padding: 0.25rem 0.8rem;">{{ status }}</span>
+        {% if reading_age_hours is none %}
+        <span style="font-family:'JetBrains Mono',monospace;font-size:0.62rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--amber);background:rgba(255,186,74,0.1);border:1px solid rgba(255,186,74,0.25);border-radius:4px;padding:3px 8px;">No data</span>
+        {% elif reading_age_hours > 2 %}
+        <span style="font-family:'JetBrains Mono',monospace;font-size:0.62rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--amber);background:rgba(255,186,74,0.1);border:1px solid rgba(255,186,74,0.25);border-radius:4px;padding:3px 8px;">Stale ({{ "%.0f"|format(reading_age_hours) }}h)</span>
+        {% endif %}
     </div>
     <div style="font-size: 0.72rem; color: var(--text-dim); letter-spacing: 0.1em; text-transform: uppercase; font-style: italic; margin-top: 0.35rem;">
         {{ plant.species }} &nbsp;·&nbsp; target {{ plant.moisture_target_min }}–{{ plant.moisture_target_max }}%

--- a/tests/test_reading_age.py
+++ b/tests/test_reading_age.py
@@ -1,0 +1,97 @@
+"""Tests for stale-reading warning (issue #35)."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from flora.config import PlantConfig
+from flora.dashboard.routes import _reading_age_hours
+from flora.db import SensorReading
+
+
+def _reading(hours_ago: float) -> SensorReading:
+    return SensorReading(
+        plant_name="basil",
+        timestamp=datetime.utcnow() - timedelta(hours=hours_ago),
+        moisture=55.0,
+        temperature=22.0,
+        light=None,
+        fertility=None,
+        battery=None,
+    )
+
+
+def test_reading_age_returns_none_when_no_reading():
+    assert _reading_age_hours(None) is None
+
+
+def test_reading_age_returns_correct_hours():
+    age = _reading_age_hours(_reading(3.0))
+    assert age == pytest.approx(3.0, abs=0.01)
+
+
+def test_reading_age_recent_reading():
+    age = _reading_age_hours(_reading(0.5))
+    assert age == pytest.approx(0.5, abs=0.01)
+
+
+def _make_app(reading: SensorReading | None):
+    from fastapi import FastAPI
+    from fastapi.templating import Jinja2Templates
+    from pathlib import Path
+    from flora.dashboard.routes import create_router
+
+    plant = PlantConfig(
+        name="basil", species="basil",
+        sensor_mac="AA:BB:CC:DD:EE:01", pump_gpio=17,
+    )
+    config = MagicMock()
+    config.plants = [plant]
+    config.plant_by_name = MagicMock(return_value=plant)
+
+    db = MagicMock()
+    db.get_latest_sensor_reading = AsyncMock(return_value=reading)
+    db.get_latest_ambient = AsyncMock(return_value=None)
+    db.get_recent_actions = AsyncMock(return_value=[])
+    db.get_journal = AsyncMock(return_value=[])
+    db.get_sensor_history = AsyncMock(return_value=[])
+
+    templates_dir = Path(__file__).parent.parent / "src" / "flora" / "dashboard" / "templates"
+    templates = Jinja2Templates(directory=str(templates_dir))
+
+    app = FastAPI()
+    app.include_router(create_router(config, db, templates))
+    return app
+
+
+def test_index_includes_reading_age_none_when_no_reading():
+    client = TestClient(_make_app(reading=None))
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "No data</span>" in resp.text
+
+
+def test_index_includes_stale_warning_for_old_reading():
+    client = TestClient(_make_app(reading=_reading(hours_ago=3.0)))
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "Stale" in resp.text
+
+
+def test_index_no_warning_for_fresh_reading():
+    client = TestClient(_make_app(reading=_reading(hours_ago=0.5)))
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "Stale" not in resp.text
+    # "No data</span>" distinguishes the stale badge from the sparkline "No data yet" text
+    assert "No data</span>" not in resp.text
+
+
+def test_plant_detail_stale_warning():
+    client = TestClient(_make_app(reading=_reading(hours_ago=5.0)))
+    resp = client.get("/plants/basil")
+    assert resp.status_code == 200
+    assert "Stale" in resp.text


### PR DESCRIPTION
## Summary
- Adds `_reading_age_hours(reading)` helper to `routes.py` — returns hours since last reading, or `None` if no reading
- Passes `reading_age_hours` to both the index and plant detail template contexts
- Shows an amber "No data" badge when reading is None, or "Stale (Xh)" when age > 2h, on plant cards (`index.html`) and the plant detail header (`plant.html`)
- 7 unit tests covering the helper and both template routes

## Test plan
- [ ] `pytest tests/test_reading_age.py -v` — 7 tests pass
- [ ] Fresh reading (< 2h): no warning shown
- [ ] Old reading (> 2h): "Stale (Xh)" amber badge visible
- [ ] No reading at all: "No data" amber badge visible

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)