### PR TITLE
Dashboard: add GET /api/health system status endpoint

### DIFF
--- a/src/flora/dashboard/routes.py
+++ b/src/flora/dashboard/routes.py
@@ -112,6 +112,30 @@ def create_router(
             f'<div class="alert alert-info">Watered {name} for {duration}s: {status}</div>'
         )
 
+    @router.get("/api/health")
+    async def health_api() -> JSONResponse:
+        """System health check: db connectivity and freshness of sensor data."""
+        readings = []
+        for plant in config.plants:
+            r = await db.get_latest_sensor_reading(plant.name)
+            if r is not None:
+                readings.append(r)
+
+        if readings:
+            newest = max(readings, key=lambda r: r.timestamp)
+            age_seconds = (datetime.utcnow() - newest.timestamp).total_seconds()
+            status = "ok" if age_seconds < 3600 else "degraded"
+        else:
+            age_seconds = None
+            status = "degraded"
+
+        return JSONResponse({
+            "status": status,
+            "plants": len(config.plants),
+            "latest_reading_age_seconds": age_seconds,
+            "db": "connected",
+        })
+
     @router.get("/api/plants/{name}/history")
     async def plant_history_api(name: str, hours: int = 48) -> JSONResponse:
         """JSON endpoint for Chart.js sensor history."""

--- a/tests/test_health_api.py
+++ b/tests/test_health_api.py
@@ -1,0 +1,94 @@
+"""Tests for GET /api/health endpoint (issue #36)."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.templating import Jinja2Templates
+from fastapi.testclient import TestClient
+from pathlib import Path
+
+from flora.config import PlantConfig
+from flora.dashboard.routes import create_router
+from flora.db import SensorReading
+
+
+def _reading(plant_name: str, hours_ago: float) -> SensorReading:
+    return SensorReading(
+        plant_name=plant_name,
+        timestamp=datetime.utcnow() - timedelta(hours=hours_ago),
+        moisture=55.0,
+        temperature=22.0,
+        light=None,
+        fertility=None,
+        battery=None,
+    )
+
+
+def _make_app(readings: dict[str, SensorReading | None]):
+    plant_names = list(readings.keys())
+    plants = [
+        PlantConfig(
+            name=name, species="basil",
+            sensor_mac=f"AA:BB:CC:DD:EE:{i:02d}", pump_gpio=17 + i,
+        )
+        for i, name in enumerate(plant_names)
+    ]
+
+    config = MagicMock()
+    config.plants = plants
+    config.plant_by_name = MagicMock(side_effect=lambda n: next((p for p in plants if p.name == n), None))
+
+    db = MagicMock()
+    db.get_latest_sensor_reading = AsyncMock(side_effect=lambda name: readings.get(name))
+    db.get_latest_ambient = AsyncMock(return_value=None)
+    db.get_recent_actions = AsyncMock(return_value=[])
+    db.get_journal = AsyncMock(return_value=[])
+    db.get_sensor_history = AsyncMock(return_value=[])
+
+    templates_dir = Path(__file__).parent.parent / "src" / "flora" / "dashboard" / "templates"
+    templates = Jinja2Templates(directory=str(templates_dir))
+
+    app = FastAPI()
+    app.include_router(create_router(config, db, templates))
+    return app
+
+
+def test_health_returns_200():
+    client = TestClient(_make_app({"basil": _reading("basil", hours_ago=0.5)}))
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+
+
+def test_health_ok_when_recent_reading():
+    client = TestClient(_make_app({"basil": _reading("basil", hours_ago=0.5)}))
+    data = client.get("/api/health").json()
+    assert data["status"] == "ok"
+    assert data["plants"] == 1
+    assert data["db"] == "connected"
+    assert data["latest_reading_age_seconds"] == pytest.approx(1800, abs=60)
+
+
+def test_health_degraded_when_old_reading():
+    client = TestClient(_make_app({"basil": _reading("basil", hours_ago=2.0)}))
+    data = client.get("/api/health").json()
+    assert data["status"] == "degraded"
+
+
+def test_health_degraded_when_no_readings():
+    client = TestClient(_make_app({"basil": None}))
+    data = client.get("/api/health").json()
+    assert data["status"] == "degraded"
+    assert data["latest_reading_age_seconds"] is None
+
+
+def test_health_uses_newest_reading_across_plants():
+    client = TestClient(_make_app({
+        "basil": _reading("basil", hours_ago=3.0),   # old
+        "mint":  _reading("mint",  hours_ago=0.25),  # recent
+    }))
+    data = client.get("/api/health").json()
+    assert data["status"] == "ok"
+    assert data["plants"] == 2


### PR DESCRIPTION
## Summary
- Adds `GET /api/health` JSON endpoint to `routes.py`
- Returns `{ status, plants, latest_reading_age_seconds, db }` — status is `"ok"` when newest reading < 1h old, `"degraded"` otherwise (or when no readings exist)
- Uses the newest reading across all plants to compute age
- 5 unit tests covering: 200 response, ok status, degraded for old reading, degraded for no readings, newest-across-plants logic

## Test plan
- [ ] `pytest tests/test_health_api.py -v` — 5 tests pass
- [ ] `curl http://localhost:8000/api/health` — returns JSON with correct fields

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)