### PR TITLE
Config: wire auto_water_min_interval_minutes through load_config

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -153,6 +153,7 @@ def load_config(path: str | Path = "flora.toml") -> AppConfig:
             moisture_target_max=p.get("moisture_target_max", 70),
             auto_water_if_below=p.get("auto_water_if_below"),
             auto_water_duration_seconds=p.get("auto_water_duration_seconds", 8),
+            auto_water_min_interval_minutes=p.get("auto_water_min_interval_minutes", 15),
             camera_index=p.get("camera_index"),
             notes=p.get("notes", ""),
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -174,3 +174,34 @@ def test_custom_dashboard_port(tmp_path: Path) -> None:
 def test_default_dashboard_port(tmp_path: Path) -> None:
     cfg = load_config(_write(tmp_path, _MINIMAL_TOML))
     assert cfg.dashboard_port == 8000
+
+
+# ---------------------------------------------------------------------------
+# 9. auto_water_min_interval_minutes loaded from TOML
+# ---------------------------------------------------------------------------
+
+_TOML_WITH_INTERVAL = """
+[anthropic]
+api_key = "sk-fake-key"
+
+[[plants]]
+name = "basil"
+species = "basil"
+sensor_mac = "AA:BB:CC:DD:EE:01"
+pump_gpio = 17
+auto_water_min_interval_minutes = 30
+"""
+
+
+def test_custom_auto_water_min_interval_minutes(tmp_path: Path) -> None:
+    cfg = load_config(_write(tmp_path, _TOML_WITH_INTERVAL))
+    basil = cfg.plant_by_name("basil")
+    assert basil is not None
+    assert basil.auto_water_min_interval_minutes == 30
+
+
+def test_default_auto_water_min_interval_minutes(tmp_path: Path) -> None:
+    cfg = load_config(_write(tmp_path, _FULL_TOML))
+    basil = cfg.plant_by_name("basil")
+    assert basil is not None
+    assert basil.auto_water_min_interval_minutes == 15


### PR DESCRIPTION
## Summary
- `load_config()` was not passing `auto_water_min_interval_minutes` when constructing `PlantConfig` from TOML — users who set this in `flora.toml` would have it silently ignored, falling back to the dataclass default of 15
- Adds `auto_water_min_interval_minutes=p.get("auto_water_min_interval_minutes", 15)` to the constructor call

## Test plan
- [ ] `test_custom_auto_water_min_interval_minutes` — custom TOML value (30) is correctly loaded
- [ ] `test_default_auto_water_min_interval_minutes` — omitting field in TOML defaults to 15

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)