### PR TITLE
Config: validate auto_water_duration_seconds range in validate_config

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -107,6 +107,12 @@ def validate_config(raw: dict) -> list[str]:
                 f"{label}: moisture_target_min ({mn}) must be less than moisture_target_max ({mx})"
             )
 
+        duration = p.get("auto_water_duration_seconds")
+        if duration is not None and not (1 <= duration <= 30):
+            errors.append(
+                f"{label}: auto_water_duration_seconds must be 1-30 (got {duration!r})"
+            )
+
     return errors
 
 

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -143,3 +143,21 @@ def test_load_config_raises_on_invalid(tmp_path):
     )
     with pytest.raises(ValueError, match="flora.toml validation failed"):
         load_config(toml)
+
+
+def test_auto_water_duration_too_low_detected():
+    raw = {"plants": [_base_plant(auto_water_duration_seconds=0)]}
+    errors = validate_config(raw)
+    assert any("auto_water_duration_seconds" in e for e in errors)
+
+
+def test_auto_water_duration_too_high_detected():
+    raw = {"plants": [_base_plant(auto_water_duration_seconds=31)]}
+    errors = validate_config(raw)
+    assert any("auto_water_duration_seconds" in e for e in errors)
+
+
+def test_auto_water_duration_valid_range_passes():
+    for val in (1, 15, 30):
+        raw = {"plants": [_base_plant(auto_water_duration_seconds=val)]}
+        assert validate_config(raw) == [], f"Expected no errors for duration={val}"


### PR DESCRIPTION
## Summary
- `validate_config()` did not check `auto_water_duration_seconds` — out-of-range values (e.g. 0 or 99) were silently clamped by the scheduler at runtime with no feedback to the user
- Adds a validation rule: value must be 1–30 (inclusive) when present

## Test plan
- [ ] `test_auto_water_duration_too_low_detected` — value 0 produces an error
- [ ] `test_auto_water_duration_too_high_detected` — value 31 produces an error
- [ ] `test_auto_water_duration_valid_range_passes` — values 1, 15, 30 all pass

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)