### PR TITLE
Config: validate moisture_target_min/max are within 0-100

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -102,6 +102,14 @@ def validate_config(raw: dict) -> list[str]:
 
         mn = p.get("moisture_target_min")
         mx = p.get("moisture_target_max")
+        if mn is not None and not (0 <= mn <= 100):
+            errors.append(
+                f"{label}: moisture_target_min must be 0-100 (got {mn!r})"
+            )
+        if mx is not None and not (0 <= mx <= 100):
+            errors.append(
+                f"{label}: moisture_target_max must be 0-100 (got {mx!r})"
+            )
         if mn is not None and mx is not None and mn >= mx:
             errors.append(
                 f"{label}: moisture_target_min ({mn}) must be less than moisture_target_max ({mx})"

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -161,3 +161,27 @@ def test_auto_water_duration_valid_range_passes():
     for val in (1, 15, 30):
         raw = {"plants": [_base_plant(auto_water_duration_seconds=val)]}
         assert validate_config(raw) == [], f"Expected no errors for duration={val}"
+
+
+def test_moisture_target_min_below_zero_detected():
+    raw = {"plants": [_base_plant(moisture_target_min=-1, moisture_target_max=70)]}
+    errors = validate_config(raw)
+    assert any("moisture_target_min" in e for e in errors)
+
+
+def test_moisture_target_max_above_100_detected():
+    raw = {"plants": [_base_plant(moisture_target_min=40, moisture_target_max=101)]}
+    errors = validate_config(raw)
+    assert any("moisture_target_max" in e for e in errors)
+
+
+def test_moisture_target_min_above_100_detected():
+    raw = {"plants": [_base_plant(moisture_target_min=110, moisture_target_max=120)]}
+    errors = validate_config(raw)
+    assert any("moisture_target_min" in e for e in errors)
+
+
+def test_moisture_target_valid_boundaries_pass():
+    for mn, mx in ((0, 1), (0, 100), (50, 100)):
+        raw = {"plants": [_base_plant(moisture_target_min=mn, moisture_target_max=mx)]}
+        assert validate_config(raw) == [], f"Expected no errors for min={mn}, max={mx}"


### PR DESCRIPTION
## Summary
- Adds range validation in `validate_config()` for `moisture_target_min` and `moisture_target_max` — both must be integers in 0–100 (inclusive)
- Appends a clear error message if either value is out of range
- Adds 4 tests covering: below-zero min, above-100 max, min above 100, and valid boundary pairs

Closes #58

## Test plan
- [ ] `python3 -m pytest tests/test_config_validation.py -q` — all 21 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)