### PR TITLE
Config: validate auto_water_min_interval_minutes is >= 1

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -121,6 +121,12 @@ def validate_config(raw: dict) -> list[str]:
                 f"{label}: auto_water_duration_seconds must be 1-30 (got {duration!r})"
             )
 
+        interval = p.get("auto_water_min_interval_minutes")
+        if interval is not None and not (interval >= 1):
+            errors.append(
+                f"{label}: auto_water_min_interval_minutes must be >= 1 (got {interval!r})"
+            )
+
     return errors
 
 

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -185,3 +185,20 @@ def test_moisture_target_valid_boundaries_pass():
     for mn, mx in ((0, 1), (0, 100), (50, 100)):
         raw = {"plants": [_base_plant(moisture_target_min=mn, moisture_target_max=mx)]}
         assert validate_config(raw) == [], f"Expected no errors for min={mn}, max={mx}"
+
+
+def test_auto_water_min_interval_zero_detected():
+    raw = {"plants": [_base_plant(auto_water_min_interval_minutes=0)]}
+    errors = validate_config(raw)
+    assert any("auto_water_min_interval_minutes" in e for e in errors)
+
+
+def test_auto_water_min_interval_negative_detected():
+    raw = {"plants": [_base_plant(auto_water_min_interval_minutes=-5)]}
+    errors = validate_config(raw)
+    assert any("auto_water_min_interval_minutes" in e for e in errors)
+
+
+def test_auto_water_min_interval_one_passes():
+    raw = {"plants": [_base_plant(auto_water_min_interval_minutes=1)]}
+    assert validate_config(raw) == []


### PR DESCRIPTION
## Summary
- Adds validation in `validate_config()` for `auto_water_min_interval_minutes`: must be >= 1
- A value of 0 or negative would disable the cooldown guard entirely, allowing rapid repeated pump firing
- Appends a clear error message if the value is invalid
- Adds 3 tests: zero detected, negative detected, value of 1 passes

Closes #59

## Test plan
- [ ] `python3 -m pytest tests/test_config_validation.py -q` — all 24 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)