### PR TITLE
Config: validate sensor_poll_interval and agent_loop_interval are >= 1

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -61,6 +61,13 @@ class AppConfig:
 def validate_config(raw: dict) -> list[str]:
     """Validate raw TOML dict and return a list of human-readable error strings."""
     errors: list[str] = []
+
+    app = raw.get("app", {})
+    for field_name in ("sensor_poll_interval", "agent_loop_interval"):
+        val = app.get(field_name)
+        if val is not None and not (val >= 1):
+            errors.append(f"[app] {field_name} must be >= 1 (got {val!r})")
+
     plants = raw.get("plants", [])
 
     seen_names: set[str] = set()

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -202,3 +202,37 @@ def test_auto_water_min_interval_negative_detected():
 def test_auto_water_min_interval_one_passes():
     raw = {"plants": [_base_plant(auto_water_min_interval_minutes=1)]}
     assert validate_config(raw) == []
+
+
+def test_sensor_poll_interval_zero_detected():
+    raw = {"app": {"sensor_poll_interval": 0}, "plants": []}
+    errors = validate_config(raw)
+    assert any("sensor_poll_interval" in e for e in errors)
+
+
+def test_sensor_poll_interval_negative_detected():
+    raw = {"app": {"sensor_poll_interval": -60}, "plants": []}
+    errors = validate_config(raw)
+    assert any("sensor_poll_interval" in e for e in errors)
+
+
+def test_sensor_poll_interval_one_passes():
+    raw = {"app": {"sensor_poll_interval": 1}, "plants": []}
+    assert validate_config(raw) == []
+
+
+def test_agent_loop_interval_zero_detected():
+    raw = {"app": {"agent_loop_interval": 0}, "plants": []}
+    errors = validate_config(raw)
+    assert any("agent_loop_interval" in e for e in errors)
+
+
+def test_agent_loop_interval_negative_detected():
+    raw = {"app": {"agent_loop_interval": -1}, "plants": []}
+    errors = validate_config(raw)
+    assert any("agent_loop_interval" in e for e in errors)
+
+
+def test_agent_loop_interval_one_passes():
+    raw = {"app": {"agent_loop_interval": 1}, "plants": []}
+    assert validate_config(raw) == []


### PR DESCRIPTION
## Summary
- Adds validation in `validate_config()` for `app.sensor_poll_interval` and `app.agent_loop_interval`: both must be >= 1 if present
- Zero or negative values would cause the scheduler to behave incorrectly (polling every 0 seconds or running in reverse)
- Adds 6 tests covering: zero, negative, and valid boundary (1) for each field

Closes #62

## Test plan
- [ ] `python3 -m pytest tests/test_config_validation.py -q` — all 30 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)