### PR TITLE
Config: validate smart_plug required fields and non-empty host

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -138,6 +138,15 @@ def validate_config(raw: dict) -> list[str]:
                 f"{label}: auto_water_min_interval_minutes must be >= 1 (got {interval!r})"
             )
 
+    for i, sp in enumerate(raw.get("smart_plugs", [])):
+        label = f"Smart plug #{i + 1}"
+        for field_name in ("alias", "host", "role"):
+            if field_name not in sp:
+                errors.append(f"{label}: missing required field '{field_name}'")
+        host = sp.get("host")
+        if host is not None and not host:
+            errors.append(f"{label}: host must not be empty")
+
     return errors
 
 

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -260,3 +260,38 @@ def test_dashboard_port_valid_boundaries_pass():
     for port in (1, 8000, 65535):
         raw = {"app": {"dashboard_port": port}, "plants": []}
         assert validate_config(raw) == [], f"Expected no errors for port={port}"
+
+
+def _base_plug(**overrides) -> dict:
+    sp = {"alias": "grow-light", "host": "192.168.1.10", "role": "grow_light"}
+    sp.update(overrides)
+    return sp
+
+
+def test_smart_plug_missing_host_detected():
+    raw = {"plants": [], "smart_plugs": [{"alias": "grow-light", "role": "grow_light"}]}
+    errors = validate_config(raw)
+    assert any("missing required field 'host'" in e for e in errors)
+
+
+def test_smart_plug_missing_alias_detected():
+    raw = {"plants": [], "smart_plugs": [{"host": "192.168.1.10", "role": "grow_light"}]}
+    errors = validate_config(raw)
+    assert any("missing required field 'alias'" in e for e in errors)
+
+
+def test_smart_plug_missing_role_detected():
+    raw = {"plants": [], "smart_plugs": [{"alias": "grow-light", "host": "192.168.1.10"}]}
+    errors = validate_config(raw)
+    assert any("missing required field 'role'" in e for e in errors)
+
+
+def test_smart_plug_empty_host_detected():
+    raw = {"plants": [], "smart_plugs": [_base_plug(host="")]}
+    errors = validate_config(raw)
+    assert any("host must not be empty" in e for e in errors)
+
+
+def test_smart_plug_valid_config_passes():
+    raw = {"plants": [], "smart_plugs": [_base_plug()]}
+    assert validate_config(raw) == []


### PR DESCRIPTION
## Summary
- Adds validation in `validate_config()` for `[[smart_plugs]]` entries:
  - Checks that `alias`, `host`, and `role` are all present (missing field → error)
  - Checks that `host` is not an empty string (empty host → connection fails at runtime)
- Adds 5 tests covering: missing host, missing alias, missing role, empty host, and a valid config

Closes #66

## Test plan
- [ ] `python3 -m pytest tests/test_config_validation.py -q` — all 39 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)