### PR TITLE
Config: validate smart_plug role is one of the known values

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -146,6 +146,11 @@ def validate_config(raw: dict) -> list[str]:
         host = sp.get("host")
         if host is not None and not host:
             errors.append(f"{label}: host must not be empty")
+        role = sp.get("role")
+        if role is not None and role not in ("grow_light", "humidifier", "fan"):
+            errors.append(
+                f"{label}: role must be one of grow_light, humidifier, fan (got {role!r})"
+            )
 
     return errors
 

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -295,3 +295,15 @@ def test_smart_plug_empty_host_detected():
 def test_smart_plug_valid_config_passes():
     raw = {"plants": [], "smart_plugs": [_base_plug()]}
     assert validate_config(raw) == []
+
+
+def test_smart_plug_unknown_role_detected():
+    raw = {"plants": [], "smart_plugs": [_base_plug(role="heater")]}
+    errors = validate_config(raw)
+    assert any("role must be one of" in e for e in errors)
+
+
+def test_smart_plug_all_valid_roles_pass():
+    for role in ("grow_light", "humidifier", "fan"):
+        raw = {"plants": [], "smart_plugs": [_base_plug(role=role)]}
+        assert validate_config(raw) == [], f"Expected no errors for role={role!r}"


### PR DESCRIPTION
## Summary
- Adds validation in `validate_config()` for each smart plug's `role` field: must be one of `grow_light`, `humidifier`, or `fan`
- Unknown roles are silently ignored by `plug_by_role()`, causing confusion — this surfaces them as clear errors at load time
- Adds 2 tests: unknown role detected, and all three valid roles pass

Closes #67

## Test plan
- [ ] `python3 -m pytest tests/test_config_validation.py -q` — all 41 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)