### PR TITLE
Config: validate auto_water_if_below is within 0-100 when set

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -138,6 +138,12 @@ def validate_config(raw: dict) -> list[str]:
                 f"{label}: auto_water_min_interval_minutes must be >= 1 (got {interval!r})"
             )
 
+        threshold = p.get("auto_water_if_below")
+        if threshold is not None and not (0 <= threshold <= 100):
+            errors.append(
+                f"{label}: auto_water_if_below must be 0-100 (got {threshold!r})"
+            )
+
     for i, sp in enumerate(raw.get("smart_plugs", [])):
         label = f"Smart plug #{i + 1}"
         for field_name in ("alias", "host", "role"):

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -307,3 +307,26 @@ def test_smart_plug_all_valid_roles_pass():
     for role in ("grow_light", "humidifier", "fan"):
         raw = {"plants": [], "smart_plugs": [_base_plug(role=role)]}
         assert validate_config(raw) == [], f"Expected no errors for role={role!r}"
+
+
+def test_auto_water_if_below_negative_detected():
+    raw = {"plants": [_base_plant(auto_water_if_below=-1)]}
+    errors = validate_config(raw)
+    assert any("auto_water_if_below" in e for e in errors)
+
+
+def test_auto_water_if_below_above_100_detected():
+    raw = {"plants": [_base_plant(auto_water_if_below=101)]}
+    errors = validate_config(raw)
+    assert any("auto_water_if_below" in e for e in errors)
+
+
+def test_auto_water_if_below_valid_boundaries_pass():
+    for val in (0, 50, 100):
+        raw = {"plants": [_base_plant(auto_water_if_below=val)]}
+        assert validate_config(raw) == [], f"Expected no errors for auto_water_if_below={val}"
+
+
+def test_auto_water_if_below_absent_passes():
+    raw = {"plants": [_base_plant()]}
+    assert validate_config(raw) == []


### PR DESCRIPTION
Adds validation in validate_config() that auto_water_if_below, when present, must be in range 0-100. Values like -1 or 101 now produce a clear error. Full suite: 191 passed, 3 skipped. Closes #70