### PR TITLE
Config: validate species is a known value

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 _MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$")
+_KNOWN_SPECIES = {"basil", "parsley", "mint", "chives", "coriander"}
 
 
 @dataclass(frozen=True)
@@ -142,6 +143,12 @@ def validate_config(raw: dict) -> list[str]:
         if threshold is not None and not (0 <= threshold <= 100):
             errors.append(
                 f"{label}: auto_water_if_below must be 0-100 (got {threshold!r})"
+            )
+
+        species = p.get("species")
+        if species is not None and species not in _KNOWN_SPECIES:
+            errors.append(
+                f"{label}: species must be one of {', '.join(sorted(_KNOWN_SPECIES))} (got {species!r})"
             )
 
     for i, sp in enumerate(raw.get("smart_plugs", [])):

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -330,3 +330,17 @@ def test_auto_water_if_below_valid_boundaries_pass():
 def test_auto_water_if_below_absent_passes():
     raw = {"plants": [_base_plant()]}
     assert validate_config(raw) == []
+
+
+# --- species validation (issue #71) ---
+
+def test_species_unknown_value_detected():
+    raw = {"plants": [_base_plant(species="tomato")]}
+    errors = validate_config(raw)
+    assert any("species" in e for e in errors)
+
+
+def test_species_all_known_values_pass():
+    for species in ("basil", "parsley", "mint", "chives", "coriander"):
+        raw = {"plants": [_base_plant(species=species)]}
+        assert validate_config(raw) == [], f"Expected no errors for species={species!r}"


### PR DESCRIPTION
Adds validation in validate_config() that species must be one of basil, parsley, mint, chives, coriander. Unknown values like 'tomato' now produce a clear error. All 189 tests pass. Closes #71