### PR TITLE
Config: validate notes field does not exceed 500 characters

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -161,6 +161,12 @@ def validate_config(raw: dict) -> list[str]:
                 f"{label}: camera_index must be >= 0 (got {camera_index!r})"
             )
 
+        notes = p.get("notes")
+        if notes is not None and len(notes) > 500:
+            errors.append(
+                f"{label}: notes must be <= 500 characters (got {len(notes)})"
+            )
+
     for i, sp in enumerate(raw.get("smart_plugs", [])):
         label = f"Smart plug #{i + 1}"
         for field_name in ("alias", "host", "role"):

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -383,3 +383,24 @@ def test_db_path_non_empty_passes():
 def test_db_path_absent_passes():
     raw = {"plants": [_base_plant()]}
     assert validate_config(raw) == []
+
+
+def test_notes_too_long_detected():
+    raw = {"plants": [_base_plant(notes="x" * 501)]}
+    errors = validate_config(raw)
+    assert any("notes" in e for e in errors)
+
+
+def test_notes_at_limit_passes():
+    raw = {"plants": [_base_plant(notes="x" * 500)]}
+    assert validate_config(raw) == []
+
+
+def test_notes_empty_passes():
+    raw = {"plants": [_base_plant(notes="")]}
+    assert validate_config(raw) == []
+
+
+def test_notes_absent_passes():
+    raw = {"plants": [_base_plant()]}
+    assert validate_config(raw) == []


### PR DESCRIPTION
## Summary
- Adds a length check on the optional plant `notes` field: max 500 characters
- Prevents UI rendering issues and database bloat from unconstrained free-text
- Adds 4 tests covering over-limit, at-limit, empty, and absent

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)