### PR TITLE
Config: validate telegram token and chat_id are paired

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -77,6 +77,14 @@ def validate_config(raw: dict) -> list[str]:
     if db_path is not None and not db_path:
         errors.append("[app] db_path must not be empty")
 
+    telegram = raw.get("telegram", {})
+    tg_token = telegram.get("token", "")
+    tg_chat_id = telegram.get("chat_id", "")
+    if bool(tg_token) != bool(tg_chat_id):
+        errors.append(
+            "[telegram] token and chat_id must both be set or both be empty"
+        )
+
     plants = raw.get("plants", [])
 
     seen_names: set[str] = set()

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -404,3 +404,30 @@ def test_notes_empty_passes():
 def test_notes_absent_passes():
     raw = {"plants": [_base_plant()]}
     assert validate_config(raw) == []
+
+
+def test_telegram_token_without_chat_id_detected():
+    raw = {"plants": [], "telegram": {"token": "abc123", "chat_id": ""}}
+    errors = validate_config(raw)
+    assert any("telegram" in e for e in errors)
+
+
+def test_telegram_chat_id_without_token_detected():
+    raw = {"plants": [], "telegram": {"token": "", "chat_id": "99999"}}
+    errors = validate_config(raw)
+    assert any("telegram" in e for e in errors)
+
+
+def test_telegram_both_set_passes():
+    raw = {"plants": [], "telegram": {"token": "abc123", "chat_id": "99999"}}
+    assert validate_config(raw) == []
+
+
+def test_telegram_both_empty_passes():
+    raw = {"plants": [], "telegram": {"token": "", "chat_id": ""}}
+    assert validate_config(raw) == []
+
+
+def test_telegram_section_absent_passes():
+    raw = {"plants": []}
+    assert validate_config(raw) == []


### PR DESCRIPTION
## Summary
- Detects when exactly one of `telegram.token` / `telegram.chat_id` is non-empty (misconfiguration that causes silent send failures)
- Both set, both empty, or section absent all pass validation
- Adds 5 tests covering all combinations

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)