### PR TITLE
Config: validate anthropic api_key is not empty

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -85,6 +85,11 @@ def validate_config(raw: dict) -> list[str]:
             "[telegram] token and chat_id must both be set or both be empty"
         )
 
+    anthropic = raw.get("anthropic", {})
+    api_key = anthropic.get("api_key")
+    if api_key is not None and not api_key:
+        errors.append("[anthropic] api_key must not be empty")
+
     plants = raw.get("plants", [])
 
     seen_names: set[str] = set()

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -431,3 +431,19 @@ def test_telegram_both_empty_passes():
 def test_telegram_section_absent_passes():
     raw = {"plants": []}
     assert validate_config(raw) == []
+
+
+def test_anthropic_api_key_empty_detected():
+    raw = {"plants": [], "anthropic": {"api_key": ""}}
+    errors = validate_config(raw)
+    assert any("api_key" in e for e in errors)
+
+
+def test_anthropic_api_key_non_empty_passes():
+    raw = {"plants": [], "anthropic": {"api_key": "sk-test-key"}}
+    assert validate_config(raw) == []
+
+
+def test_anthropic_section_absent_passes():
+    raw = {"plants": []}
+    assert validate_config(raw) == []


### PR DESCRIPTION
## Summary
- Errors when `[anthropic] api_key` is explicitly set to an empty string
- Prevents confusing auth failures at the first Claude API call
- Adds 3 tests: empty key, non-empty key, absent section

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)