### PR TITLE
Config: add test that pump_gpio float is rejected

### DIFF
--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -447,3 +447,9 @@ def test_anthropic_api_key_non_empty_passes():
 def test_anthropic_section_absent_passes():
     raw = {"plants": []}
     assert validate_config(raw) == []
+
+
+def test_pump_gpio_float_detected():
+    raw = {"plants": [_base_plant(pump_gpio=17.0)]}
+    errors = validate_config(raw)
+    assert any("pump_gpio" in e for e in errors)


### PR DESCRIPTION
## Summary
- The existing `isinstance(gpio, int)` check already rejects floats like `17.0`
- This PR adds the missing test to document and protect that behaviour
- No production code change needed

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)