### PR TITLE
Config: detect duplicate smart_plug alias and host

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -180,14 +180,31 @@ def validate_config(raw: dict) -> list[str]:
                 f"{label}: notes must be <= 500 characters (got {len(notes)})"
             )
 
+    seen_plug_aliases: set[str] = set()
+    seen_plug_hosts: set[str] = set()
+
     for i, sp in enumerate(raw.get("smart_plugs", [])):
         label = f"Smart plug #{i + 1}"
         for field_name in ("alias", "host", "role"):
             if field_name not in sp:
                 errors.append(f"{label}: missing required field '{field_name}'")
+
+        alias = sp.get("alias")
+        if alias is not None:
+            if alias in seen_plug_aliases:
+                errors.append(f"{label}: duplicate alias '{alias}'")
+            else:
+                seen_plug_aliases.add(alias)
+
         host = sp.get("host")
         if host is not None and not host:
             errors.append(f"{label}: host must not be empty")
+        elif host is not None:
+            if host in seen_plug_hosts:
+                errors.append(f"{label}: duplicate host '{host}'")
+            else:
+                seen_plug_hosts.add(host)
+
         role = sp.get("role")
         if role is not None and role not in ("grow_light", "humidifier", "fan"):
             errors.append(

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -453,3 +453,49 @@ def test_pump_gpio_float_detected():
     raw = {"plants": [_base_plant(pump_gpio=17.0)]}
     errors = validate_config(raw)
     assert any("pump_gpio" in e for e in errors)
+
+
+def test_smart_plug_duplicate_alias_detected():
+    raw = {
+        "plants": [],
+        "smart_plugs": [
+            _base_plug(alias="grow-light", host="192.168.1.10"),
+            _base_plug(alias="grow-light", host="192.168.1.11"),
+        ],
+    }
+    errors = validate_config(raw)
+    assert any("duplicate alias" in e for e in errors)
+
+
+def test_smart_plug_unique_aliases_pass():
+    raw = {
+        "plants": [],
+        "smart_plugs": [
+            _base_plug(alias="grow-light", host="192.168.1.10"),
+            _base_plug(alias="humidifier", host="192.168.1.11", role="humidifier"),
+        ],
+    }
+    assert validate_config(raw) == []
+
+
+def test_smart_plug_duplicate_host_detected():
+    raw = {
+        "plants": [],
+        "smart_plugs": [
+            _base_plug(alias="grow-light", host="192.168.1.10"),
+            _base_plug(alias="humidifier", host="192.168.1.10", role="humidifier"),
+        ],
+    }
+    errors = validate_config(raw)
+    assert any("duplicate host" in e for e in errors)
+
+
+def test_smart_plug_unique_hosts_pass():
+    raw = {
+        "plants": [],
+        "smart_plugs": [
+            _base_plug(alias="grow-light", host="192.168.1.10"),
+            _base_plug(alias="humidifier", host="192.168.1.11", role="humidifier"),
+        ],
+    }
+    assert validate_config(raw) == []


### PR DESCRIPTION
## Summary
- Detects duplicate `alias` across smart plugs (closes #85)
- Detects duplicate `host` across smart plugs (closes #86)
- Adds 4 tests covering both duplicate and unique cases

Closes #85, closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)