### PR TITLE
Config: validate moisture targets are integers and model not empty

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -89,6 +89,9 @@ def validate_config(raw: dict) -> list[str]:
     api_key = anthropic.get("api_key")
     if api_key is not None and not api_key:
         errors.append("[anthropic] api_key must not be empty")
+    model = anthropic.get("model")
+    if model is not None and not model:
+        errors.append("[anthropic] model must not be empty")
 
     plants = raw.get("plants", [])
 
@@ -131,11 +134,19 @@ def validate_config(raw: dict) -> list[str]:
 
         mn = p.get("moisture_target_min")
         mx = p.get("moisture_target_max")
-        if mn is not None and not (0 <= mn <= 100):
+        if mn is not None and not isinstance(mn, int):
+            errors.append(
+                f"{label}: moisture_target_min must be an integer (got {mn!r})"
+            )
+        elif mn is not None and not (0 <= mn <= 100):
             errors.append(
                 f"{label}: moisture_target_min must be 0-100 (got {mn!r})"
             )
-        if mx is not None and not (0 <= mx <= 100):
+        if mx is not None and not isinstance(mx, int):
+            errors.append(
+                f"{label}: moisture_target_max must be an integer (got {mx!r})"
+            )
+        elif mx is not None and not (0 <= mx <= 100):
             errors.append(
                 f"{label}: moisture_target_max must be 0-100 (got {mx!r})"
             )

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -499,3 +499,36 @@ def test_smart_plug_unique_hosts_pass():
         ],
     }
     assert validate_config(raw) == []
+
+
+def test_moisture_target_min_float_detected():
+    raw = {"plants": [_base_plant(moisture_target_min=40.5, moisture_target_max=70)]}
+    errors = validate_config(raw)
+    assert any("moisture_target_min" in e for e in errors)
+
+
+def test_moisture_target_max_float_detected():
+    raw = {"plants": [_base_plant(moisture_target_min=40, moisture_target_max=70.5)]}
+    errors = validate_config(raw)
+    assert any("moisture_target_max" in e for e in errors)
+
+
+def test_moisture_target_integer_values_pass():
+    raw = {"plants": [_base_plant(moisture_target_min=40, moisture_target_max=70)]}
+    assert validate_config(raw) == []
+
+
+def test_anthropic_model_empty_detected():
+    raw = {"plants": [], "anthropic": {"api_key": "sk-test", "model": ""}}
+    errors = validate_config(raw)
+    assert any("model" in e for e in errors)
+
+
+def test_anthropic_model_non_empty_passes():
+    raw = {"plants": [], "anthropic": {"api_key": "sk-test", "model": "claude-sonnet-4-6"}}
+    assert validate_config(raw) == []
+
+
+def test_anthropic_model_absent_passes():
+    raw = {"plants": [], "anthropic": {"api_key": "sk-test"}}
+    assert validate_config(raw) == []


### PR DESCRIPTION
## Summary
- Rejects float moisture targets like `40.5` that silently pass the existing range check (closes #88)
- Errors when `[anthropic] model` is explicitly set to an empty string (closes #89)
- Adds 6 tests total

Closes #88, closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)