### PR TITLE
Config: validate intervals and dashboard_port are integers

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -66,11 +66,15 @@ def validate_config(raw: dict) -> list[str]:
     app = raw.get("app", {})
     for field_name in ("sensor_poll_interval", "agent_loop_interval"):
         val = app.get(field_name)
-        if val is not None and not (val >= 1):
+        if val is not None and not isinstance(val, int):
+            errors.append(f"[app] {field_name} must be an integer (got {val!r})")
+        elif val is not None and not (val >= 1):
             errors.append(f"[app] {field_name} must be >= 1 (got {val!r})")
 
     port = app.get("dashboard_port")
-    if port is not None and not (1 <= port <= 65535):
+    if port is not None and not isinstance(port, int):
+        errors.append(f"[app] dashboard_port must be an integer (got {port!r})")
+    elif port is not None and not (1 <= port <= 65535):
         errors.append(f"[app] dashboard_port must be 1-65535 (got {port!r})")
 
     db_path = app.get("db_path")

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -532,3 +532,31 @@ def test_anthropic_model_non_empty_passes():
 def test_anthropic_model_absent_passes():
     raw = {"plants": [], "anthropic": {"api_key": "sk-test"}}
     assert validate_config(raw) == []
+
+
+def test_sensor_poll_interval_float_detected():
+    raw = {"app": {"sensor_poll_interval": 1800.5}, "plants": []}
+    errors = validate_config(raw)
+    assert any("sensor_poll_interval" in e for e in errors)
+
+
+def test_agent_loop_interval_float_detected():
+    raw = {"app": {"agent_loop_interval": 3600.0}, "plants": []}
+    errors = validate_config(raw)
+    assert any("agent_loop_interval" in e for e in errors)
+
+
+def test_interval_integer_values_pass():
+    raw = {"app": {"sensor_poll_interval": 1800, "agent_loop_interval": 7200}, "plants": []}
+    assert validate_config(raw) == []
+
+
+def test_dashboard_port_float_detected():
+    raw = {"app": {"dashboard_port": 8000.0}, "plants": []}
+    errors = validate_config(raw)
+    assert any("dashboard_port" in e for e in errors)
+
+
+def test_dashboard_port_integer_passes():
+    raw = {"app": {"dashboard_port": 8000}, "plants": []}
+    assert validate_config(raw) == []


### PR DESCRIPTION
## Summary
- Rejects float `sensor_poll_interval` and `agent_loop_interval` values (closes #91)
- Rejects float `dashboard_port` values like `8000.0` that would cause a uvicorn TypeError (closes #92)
- Adds 5 tests total

Closes #91, closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)