### PR TITLE
Config: validate auto_water_duration_seconds and min_interval_minutes are integers

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -160,13 +160,21 @@ def validate_config(raw: dict) -> list[str]:
             )
 
         duration = p.get("auto_water_duration_seconds")
-        if duration is not None and not (1 <= duration <= 30):
+        if duration is not None and not isinstance(duration, int):
+            errors.append(
+                f"{label}: auto_water_duration_seconds must be an integer (got {duration!r})"
+            )
+        elif duration is not None and not (1 <= duration <= 30):
             errors.append(
                 f"{label}: auto_water_duration_seconds must be 1-30 (got {duration!r})"
             )
 
         interval = p.get("auto_water_min_interval_minutes")
-        if interval is not None and not (interval >= 1):
+        if interval is not None and not isinstance(interval, int):
+            errors.append(
+                f"{label}: auto_water_min_interval_minutes must be an integer (got {interval!r})"
+            )
+        elif interval is not None and not (interval >= 1):
             errors.append(
                 f"{label}: auto_water_min_interval_minutes must be >= 1 (got {interval!r})"
             )

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -560,3 +560,25 @@ def test_dashboard_port_float_detected():
 def test_dashboard_port_integer_passes():
     raw = {"app": {"dashboard_port": 8000}, "plants": []}
     assert validate_config(raw) == []
+
+
+def test_auto_water_duration_float_detected():
+    raw = {"plants": [_base_plant(auto_water_duration_seconds=8.5)]}
+    errors = validate_config(raw)
+    assert any("auto_water_duration_seconds" in e for e in errors)
+
+
+def test_auto_water_duration_integer_passes():
+    raw = {"plants": [_base_plant(auto_water_duration_seconds=8)]}
+    assert validate_config(raw) == []
+
+
+def test_auto_water_min_interval_float_detected():
+    raw = {"plants": [_base_plant(auto_water_min_interval_minutes=15.5)]}
+    errors = validate_config(raw)
+    assert any("auto_water_min_interval_minutes" in e for e in errors)
+
+
+def test_auto_water_min_interval_integer_passes():
+    raw = {"plants": [_base_plant(auto_water_min_interval_minutes=15)]}
+    assert validate_config(raw) == []


### PR DESCRIPTION
## Summary
- Rejects float `auto_water_duration_seconds` (closes #94)
- Rejects float `auto_water_min_interval_minutes` (closes #95)
- Adds 4 tests total

Closes #94, closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)