### PR TITLE
Config: validate auto_water_if_below is an integer

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -180,7 +180,11 @@ def validate_config(raw: dict) -> list[str]:
             )
 
         threshold = p.get("auto_water_if_below")
-        if threshold is not None and not (0 <= threshold <= 100):
+        if threshold is not None and not isinstance(threshold, int):
+            errors.append(
+                f"{label}: auto_water_if_below must be an integer (got {threshold!r})"
+            )
+        elif threshold is not None and not (0 <= threshold <= 100):
             errors.append(
                 f"{label}: auto_water_if_below must be 0-100 (got {threshold!r})"
             )

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -582,3 +582,14 @@ def test_auto_water_min_interval_float_detected():
 def test_auto_water_min_interval_integer_passes():
     raw = {"plants": [_base_plant(auto_water_min_interval_minutes=15)]}
     assert validate_config(raw) == []
+
+
+def test_auto_water_if_below_float_detected():
+    raw = {"plants": [_base_plant(auto_water_if_below=45.5)]}
+    errors = validate_config(raw)
+    assert any("auto_water_if_below" in e for e in errors)
+
+
+def test_auto_water_if_below_integer_passes():
+    raw = {"plants": [_base_plant(auto_water_if_below=45)]}
+    assert validate_config(raw) == []


### PR DESCRIPTION
## Summary
- Adds isinstance check for `auto_water_if_below` before the existing 0-100 range check
- Floats like `45.5` are now rejected; integers continue to pass
- Adds 2 tests

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)