### PR TITLE
Config: validate plant name contains only safe characters

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 _MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$")
 _KNOWN_SPECIES = {"basil", "parsley", "mint", "chives", "coriander"}
+# Safe characters for plant names used in dashboard URLs and log messages
+_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 # IPv4 (octet-range clamped 0-255) or RFC-1123 hostname labels
 _HOST_RE = re.compile(
     r"^(?:"
@@ -121,6 +123,12 @@ def validate_config(raw: dict) -> list[str]:
 
         name = p.get("name")
         if name is not None:
+            if not name:
+                errors.append(f"{label}: name must not be empty")
+            elif not _NAME_RE.match(name):
+                errors.append(
+                    f"{label}: name must contain only letters, digits, underscores, or hyphens (got {name!r})"
+                )
             if name in seen_names:
                 errors.append(f"{label}: duplicate plant name '{name}'")
             seen_names.add(name)

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -612,3 +612,28 @@ def test_plug_host_invalid_format_detected():
         raw = {"plants": [], "smart_plugs": [_base_plug(host=host)]}
         errors = validate_config(raw)
         assert any("host" in e for e in errors), f"Expected error for host={host!r}"
+
+
+def test_plant_name_valid_chars_pass():
+    for name in ("basil", "my-herb", "herb_1", "Mint", "coriander-2"):
+        raw = {"plants": [_base_plant(name=name)]}
+        assert validate_config(raw) == [], f"Expected no errors for name={name!r}"
+
+
+def test_plant_name_with_space_detected():
+    raw = {"plants": [_base_plant(name="my basil")]}
+    errors = validate_config(raw)
+    assert any("name" in e for e in errors)
+
+
+def test_plant_name_with_special_char_detected():
+    for name in ("basil!", "herb@home", "mint/1"):
+        raw = {"plants": [_base_plant(name=name)]}
+        errors = validate_config(raw)
+        assert any("name" in e for e in errors), f"Expected error for name={name!r}"
+
+
+def test_plant_name_empty_detected():
+    raw = {"plants": [_base_plant(name="")]}
+    errors = validate_config(raw)
+    assert any("name" in e for e in errors)


### PR DESCRIPTION
## Summary
- Adds `_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")` constant (with comment) for plant name validation
- Validates that plant `name` is non-empty and contains only letters, digits, underscores, or hyphens — safe for use in dashboard URLs and log messages
- Tests cover: valid names, names with spaces, names with special characters, and empty names

Closes #102

## Test plan
- [ ] `pytest tests/test_config_validation.py -v` passes (95 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)