### PR TITLE
Config: validate smart_plug alias contains only safe characters

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -234,6 +234,12 @@ def validate_config(raw: dict) -> list[str]:
 
         alias = sp.get("alias")
         if alias is not None:
+            if not alias:
+                errors.append(f"{label}: alias must not be empty")
+            elif not _NAME_RE.match(alias):
+                errors.append(
+                    f"{label}: alias must contain only letters, digits, underscores, or hyphens (got {alias!r})"
+                )
             if alias in seen_plug_aliases:
                 errors.append(f"{label}: duplicate alias '{alias}'")
             else:

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -637,3 +637,28 @@ def test_plant_name_empty_detected():
     raw = {"plants": [_base_plant(name="")]}
     errors = validate_config(raw)
     assert any("name" in e for e in errors)
+
+
+def test_plug_alias_valid_chars_pass():
+    for alias in ("grow-light", "humidifier_1", "fan", "MyFan"):
+        raw = {"plants": [], "smart_plugs": [_base_plug(alias=alias)]}
+        assert validate_config(raw) == [], f"Expected no errors for alias={alias!r}"
+
+
+def test_plug_alias_with_space_detected():
+    raw = {"plants": [], "smart_plugs": [_base_plug(alias="grow light")]}
+    errors = validate_config(raw)
+    assert any("alias" in e for e in errors)
+
+
+def test_plug_alias_with_special_char_detected():
+    for alias in ("fan!", "plug@home", "light/1"):
+        raw = {"plants": [], "smart_plugs": [_base_plug(alias=alias)]}
+        errors = validate_config(raw)
+        assert any("alias" in e for e in errors), f"Expected error for alias={alias!r}"
+
+
+def test_plug_alias_empty_detected():
+    raw = {"plants": [], "smart_plugs": [_base_plug(alias="")]}
+    errors = validate_config(raw)
+    assert any("alias" in e for e in errors)


### PR DESCRIPTION
## Summary
- Reuses existing `_NAME_RE` to validate that `alias` is non-empty and contains only `[a-zA-Z0-9_-]`
- Tests cover: valid aliases, aliases with spaces, aliases with special characters, empty alias

Closes #105

## Test plan
- [ ] `pytest tests/test_config_validation.py -v` passes (99 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)