### PR TITLE
Config: validate anthropic model string length and no whitespace

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -106,6 +106,10 @@ def validate_config(raw: dict) -> list[str]:
     model = anthropic.get("model")
     if model is not None and not model:
         errors.append("[anthropic] model must not be empty")
+    elif model is not None and len(model) > 100:
+        errors.append(f"[anthropic] model must be <= 100 characters (got {len(model)})")
+    elif model is not None and any(c in model for c in (" ", "\t", "\n")):
+        errors.append(f"[anthropic] model must not contain whitespace (got {model!r})")
 
     plants = raw.get("plants", [])
 

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -662,3 +662,31 @@ def test_plug_alias_empty_detected():
     raw = {"plants": [], "smart_plugs": [_base_plug(alias="")]}
     errors = validate_config(raw)
     assert any("alias" in e for e in errors)
+
+
+def test_model_valid_passes():
+    raw = {"anthropic": {"api_key": "sk-fake", "model": "claude-sonnet-4-6"}}
+    assert validate_config(raw) == []
+
+
+def test_model_too_long_detected():
+    raw = {"anthropic": {"api_key": "sk-fake", "model": "x" * 101}}
+    errors = validate_config(raw)
+    assert any("model" in e for e in errors)
+
+
+def test_model_with_space_detected():
+    raw = {"anthropic": {"api_key": "sk-fake", "model": "claude sonnet"}}
+    errors = validate_config(raw)
+    assert any("model" in e for e in errors)
+
+
+def test_model_with_newline_detected():
+    raw = {"anthropic": {"api_key": "sk-fake", "model": "claude\nsonnet"}}
+    errors = validate_config(raw)
+    assert any("model" in e for e in errors)
+
+
+def test_model_exactly_100_chars_passes():
+    raw = {"anthropic": {"api_key": "sk-fake", "model": "a" * 100}}
+    assert validate_config(raw) == []


### PR DESCRIPTION
## Summary
- Returns an error if `model` exceeds 100 characters (guards against obvious misconfiguration)
- Returns an error if `model` contains whitespace (spaces, tabs, newlines) — Claude model IDs never contain whitespace
- Uses `elif` chaining to avoid double-reporting when the field is already empty

Closes #106

## Test plan
- [ ] `pytest tests/test_config_validation.py -v` passes (104 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)