### PR TITLE
Config: validate telegram token format and chat_id is numeric

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -12,6 +12,10 @@ from pathlib import Path
 
 _MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$")
 _KNOWN_SPECIES = {"basil", "parsley", "mint", "chives", "coriander"}
+# Telegram bot token: <numeric_bot_id>:<alphanumeric_secret>
+_TG_TOKEN_RE = re.compile(r"^\d+:[A-Za-z0-9_-]+$")
+# Telegram chat_id: integer (positive for users/channels, negative for groups)
+_TG_CHAT_ID_RE = re.compile(r"^-?\d+$")
 # Safe characters for plant names used in dashboard URLs and log messages
 _NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 # IPv4 (octet-range clamped 0-255) or RFC-1123 hostname labels
@@ -97,6 +101,14 @@ def validate_config(raw: dict) -> list[str]:
     if bool(tg_token) != bool(tg_chat_id):
         errors.append(
             "[telegram] token and chat_id must both be set or both be empty"
+        )
+    if tg_token and not _TG_TOKEN_RE.match(tg_token):
+        errors.append(
+            f"[telegram] token must be in the format <bot_id>:<secret> (got {tg_token!r})"
+        )
+    if tg_chat_id and not _TG_CHAT_ID_RE.match(tg_chat_id):
+        errors.append(
+            f"[telegram] chat_id must be an integer (got {tg_chat_id!r})"
         )
 
     anthropic = raw.get("anthropic", {})

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -421,7 +421,7 @@ def test_telegram_chat_id_without_token_detected():
 
 
 def test_telegram_both_set_passes():
-    raw = {"plants": [], "telegram": {"token": "abc123", "chat_id": "99999"}}
+    raw = {"plants": [], "telegram": {"token": "123456789:ABCdef", "chat_id": "99999"}}
     assert validate_config(raw) == []
 
 
@@ -721,3 +721,31 @@ def test_auto_water_if_below_absent_no_cross_error():
 def test_moisture_target_min_absent_no_cross_error():
     raw = {"plants": [_base_plant(auto_water_if_below=30)]}
     assert validate_config(raw) == []
+
+
+def test_telegram_valid_token_and_chat_id_pass():
+    raw = {"telegram": {"token": "123456789:ABCdef-ghiJKL_mnoPQR", "chat_id": "987654321"}}
+    assert validate_config(raw) == []
+
+
+def test_telegram_group_chat_id_passes():
+    raw = {"telegram": {"token": "123456789:ABCdef", "chat_id": "-100123456789"}}
+    assert validate_config(raw) == []
+
+
+def test_telegram_token_missing_colon_detected():
+    raw = {"telegram": {"token": "123456789ABCdef", "chat_id": "123"}}
+    errors = validate_config(raw)
+    assert any("token" in e for e in errors)
+
+
+def test_telegram_token_non_numeric_id_detected():
+    raw = {"telegram": {"token": "abc:ABCdef", "chat_id": "123"}}
+    errors = validate_config(raw)
+    assert any("token" in e for e in errors)
+
+
+def test_telegram_chat_id_non_numeric_detected():
+    raw = {"telegram": {"token": "123456789:ABCdef", "chat_id": "my_group"}}
+    errors = validate_config(raw)
+    assert any("chat_id" in e for e in errors)


### PR DESCRIPTION
## Summary
- Adds `_TG_TOKEN_RE` (matches `<numeric_bot_id>:<alphanumeric_secret>`) and `_TG_CHAT_ID_RE` (matches integer, optionally negative for groups)
- Validates token format and chat_id are integers when set
- Updates existing `test_telegram_both_set_passes` which used an invalid fake token `"abc123"` → now uses `"123456789:ABCdef"`

Closes #109

## Test plan
- [ ] `pytest tests/test_config_validation.py -v` passes (114 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)