### PR TITLE
Config: cap sensor_poll_interval and agent_loop_interval at 86400s

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -82,8 +82,8 @@ def validate_config(raw: dict) -> list[str]:
         val = app.get(field_name)
         if val is not None and not isinstance(val, int):
             errors.append(f"[app] {field_name} must be an integer (got {val!r})")
-        elif val is not None and not (val >= 1):
-            errors.append(f"[app] {field_name} must be >= 1 (got {val!r})")
+        elif val is not None and not (1 <= val <= 86400):
+            errors.append(f"[app] {field_name} must be 1-86400 (got {val!r})")
 
     port = app.get("dashboard_port")
     if port is not None and not isinstance(port, int):

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -749,3 +749,25 @@ def test_telegram_chat_id_non_numeric_detected():
     raw = {"telegram": {"token": "123456789:ABCdef", "chat_id": "my_group"}}
     errors = validate_config(raw)
     assert any("chat_id" in e for e in errors)
+
+
+def test_sensor_poll_interval_max_boundary_passes():
+    raw = {"app": {"sensor_poll_interval": 86400}}
+    assert validate_config(raw) == []
+
+
+def test_sensor_poll_interval_above_max_detected():
+    raw = {"app": {"sensor_poll_interval": 86401}}
+    errors = validate_config(raw)
+    assert any("sensor_poll_interval" in e for e in errors)
+
+
+def test_agent_loop_interval_max_boundary_passes():
+    raw = {"app": {"agent_loop_interval": 86400}}
+    assert validate_config(raw) == []
+
+
+def test_agent_loop_interval_above_max_detected():
+    raw = {"app": {"agent_loop_interval": 86401}}
+    errors = validate_config(raw)
+    assert any("agent_loop_interval" in e for e in errors)


### PR DESCRIPTION
## Summary
- Changes the lower-bound-only check (`>= 1`) to a range check (`1-86400`) for both `sensor_poll_interval` and `agent_loop_interval`
- 86400 seconds = 24 hours, a practical upper bound that catches obvious misconfiguration (e.g. accidentally entering milliseconds)

Closes #113

## Test plan
- [ ] `pytest tests/test_config_validation.py -v` passes (118 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)