### PR TITLE
Config: warn when pump_gpio uses a reserved Raspberry Pi pin

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 _MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$")
 _KNOWN_SPECIES = {"basil", "parsley", "mint", "chives", "coriander"}
+# Pins reserved for I2C (0,1) and UART (14,15) on Raspberry Pi
+_RESERVED_GPIO = {0, 1, 14, 15}
 # Telegram bot token: <numeric_bot_id>:<alphanumeric_secret>
 _TG_TOKEN_RE = re.compile(r"^\d+:[A-Za-z0-9_-]+$")
 # Telegram chat_id: integer (positive for users/channels, negative for groups)
@@ -168,10 +170,13 @@ def validate_config(raw: dict) -> list[str]:
         if gpio is not None:
             if not isinstance(gpio, int) or not (0 <= gpio <= 27):
                 errors.append(f"{label}: pump_gpio must be an integer 0-27 (got {gpio!r})")
-            elif gpio in seen_gpios:
-                errors.append(f"{label}: duplicate pump_gpio {gpio}")
             else:
-                seen_gpios.add(gpio)
+                if gpio in _RESERVED_GPIO:
+                    errors.append(f"{label}: pump_gpio {gpio} is reserved on Raspberry Pi")
+                if gpio in seen_gpios:
+                    errors.append(f"{label}: duplicate pump_gpio {gpio}")
+                else:
+                    seen_gpios.add(gpio)
 
         mn = p.get("moisture_target_min")
         mx = p.get("moisture_target_max")

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -787,3 +787,18 @@ def test_api_key_set_with_no_plants_detected():
 def test_api_key_absent_with_no_plants_passes():
     raw = {"plants": []}
     assert validate_config(raw) == []
+
+
+def test_pump_gpio_reserved_pins_detected():
+    for pin in (0, 1, 14, 15):
+        p = _base_plant(pump_gpio=pin)
+        raw = {"plants": [p]}
+        errors = validate_config(raw)
+        assert any("reserved" in e for e in errors), f"Expected reserved error for pin {pin}"
+
+
+def test_pump_gpio_non_reserved_passes():
+    for pin in (17, 27, 2, 3, 4):
+        p = _base_plant(pump_gpio=pin)
+        raw = {"plants": [p]}
+        assert validate_config(raw) == [], f"Expected no errors for pin {pin}"


### PR DESCRIPTION
## Summary
- Adds `_RESERVED_GPIO = {0, 1, 14, 15}` (I2C and UART pins on Raspberry Pi)
- Returns an error when a plant's `pump_gpio` uses a reserved pin
- Tests cover: all 4 reserved pins detected, common relay pins (2-4, 17, 27) pass

Closes #117

## Test plan
- [ ] `pytest tests/test_config_validation.py -v` passes (123 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)