### PR TITLE
Config: validate api_key length >= 20 and no whitespace

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -117,6 +117,10 @@ def validate_config(raw: dict) -> list[str]:
     api_key = anthropic.get("api_key")
     if api_key is not None and not api_key:
         errors.append("[anthropic] api_key must not be empty")
+    elif api_key is not None and len(api_key) < 20:
+        errors.append(f"[anthropic] api_key must be at least 20 characters (got {len(api_key)})")
+    elif api_key is not None and any(c in api_key for c in (" ", "\t", "\n")):
+        errors.append("[anthropic] api_key must not contain whitespace")
     model = anthropic.get("model")
     if model is not None and not model:
         errors.append("[anthropic] model must not be empty")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,7 @@ from flora.config import AppConfig, PlantConfig, SmartPlugConfig, load_config
 
 _MINIMAL_TOML = """
 [anthropic]
-api_key = "sk-fake-key"
+api_key = "sk-ant-xxxxxxxxxxxxxxxxxxxx"
 
 [[plants]]
 name = "basil"
@@ -27,7 +27,7 @@ sensor_poll_interval = 600
 agent_loop_interval = 3600
 
 [anthropic]
-api_key = "sk-fake-key"
+api_key = "sk-ant-xxxxxxxxxxxxxxxxxxxx"
 model = "claude-test-model"
 
 [telegram]
@@ -71,7 +71,7 @@ def test_load_full_config(tmp_path: Path) -> None:
     assert isinstance(cfg, AppConfig)
     assert len(cfg.plants) == 2
     assert len(cfg.smart_plugs) == 1
-    assert cfg.anthropic_api_key == "sk-fake-key"
+    assert cfg.anthropic_api_key == "sk-ant-xxxxxxxxxxxxxxxxxxxx"
     assert cfg.anthropic_model == "claude-test-model"
     assert cfg.telegram_token == "123456789:ABCdefGHIjklMNO"
     assert cfg.telegram_chat_id == "12345"
@@ -188,7 +188,7 @@ def test_default_dashboard_port(tmp_path: Path) -> None:
 
 _TOML_WITH_INTERVAL = """
 [anthropic]
-api_key = "sk-fake-key"
+api_key = "sk-ant-xxxxxxxxxxxxxxxxxxxx"
 
 [[plants]]
 name = "basil"
@@ -225,7 +225,7 @@ sensor_poll_interval = 1800
 agent_loop_interval = 7200
 
 [anthropic]
-api_key = "sk-fake-key"
+api_key = "sk-ant-xxxxxxxxxxxxxxxxxxxx"
 model = "claude-sonnet-4-6"
 
 [telegram]

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -136,7 +136,7 @@ def test_load_config_raises_on_invalid(tmp_path):
     toml = tmp_path / "flora.toml"
     toml.write_text(
         '[app]\ndb_path = "flora.db"\n'
-        '[anthropic]\napi_key = "sk-test"\n'
+        '[anthropic]\napi_key = "sk-ant-xxxxxxxxxxxxxxxxxxxx"\n'
         '[telegram]\ntoken = ""\nchat_id = ""\n'
         '[[plants]]\nname = "basil"\nspecies = "basil"\n'
         'sensor_mac = "BADMAC"\npump_gpio = 17\n'
@@ -442,7 +442,7 @@ def test_anthropic_api_key_empty_detected():
 
 
 def test_anthropic_api_key_non_empty_passes():
-    raw = {"plants": [_base_plant()], "anthropic": {"api_key": "sk-test-key"}}
+    raw = {"plants": [_base_plant()], "anthropic": {"api_key": "sk-ant-" + "x" * 20}}
     assert validate_config(raw) == []
 
 
@@ -521,18 +521,18 @@ def test_moisture_target_integer_values_pass():
 
 
 def test_anthropic_model_empty_detected():
-    raw = {"plants": [_base_plant()], "anthropic": {"api_key": "sk-test", "model": ""}}
+    raw = {"plants": [_base_plant()], "anthropic": {"api_key": "sk-ant-" + "x" * 20, "model": ""}}
     errors = validate_config(raw)
     assert any("model" in e for e in errors)
 
 
 def test_anthropic_model_non_empty_passes():
-    raw = {"plants": [_base_plant()], "anthropic": {"api_key": "sk-test", "model": "claude-sonnet-4-6"}}
+    raw = {"plants": [_base_plant()], "anthropic": {"api_key": "sk-ant-" + "x" * 20, "model": "claude-sonnet-4-6"}}
     assert validate_config(raw) == []
 
 
 def test_anthropic_model_absent_passes():
-    raw = {"plants": [_base_plant()], "anthropic": {"api_key": "sk-test"}}
+    raw = {"plants": [_base_plant()], "anthropic": {"api_key": "sk-ant-" + "x" * 20}}
     assert validate_config(raw) == []
 
 
@@ -669,30 +669,30 @@ def test_plug_alias_empty_detected():
 
 
 def test_model_valid_passes():
-    raw = {"anthropic": {"api_key": "sk-fake", "model": "claude-sonnet-4-6"}, "plants": [_base_plant()]}
+    raw = {"anthropic": {"api_key": "sk-ant-" + "x" * 20, "model": "claude-sonnet-4-6"}, "plants": [_base_plant()]}
     assert validate_config(raw) == []
 
 
 def test_model_too_long_detected():
-    raw = {"anthropic": {"api_key": "sk-fake", "model": "x" * 101}, "plants": [_base_plant()]}
+    raw = {"anthropic": {"api_key": "sk-ant-" + "x" * 20, "model": "x" * 101}, "plants": [_base_plant()]}
     errors = validate_config(raw)
     assert any("model" in e for e in errors)
 
 
 def test_model_with_space_detected():
-    raw = {"anthropic": {"api_key": "sk-fake", "model": "claude sonnet"}, "plants": [_base_plant()]}
+    raw = {"anthropic": {"api_key": "sk-ant-" + "x" * 20, "model": "claude sonnet"}, "plants": [_base_plant()]}
     errors = validate_config(raw)
     assert any("model" in e for e in errors)
 
 
 def test_model_with_newline_detected():
-    raw = {"anthropic": {"api_key": "sk-fake", "model": "claude\nsonnet"}, "plants": [_base_plant()]}
+    raw = {"anthropic": {"api_key": "sk-ant-" + "x" * 20, "model": "claude\nsonnet"}, "plants": [_base_plant()]}
     errors = validate_config(raw)
     assert any("model" in e for e in errors)
 
 
 def test_model_exactly_100_chars_passes():
-    raw = {"anthropic": {"api_key": "sk-fake", "model": "a" * 100}, "plants": [_base_plant()]}
+    raw = {"anthropic": {"api_key": "sk-ant-" + "x" * 20, "model": "a" * 100}, "plants": [_base_plant()]}
     assert validate_config(raw) == []
 
 
@@ -774,12 +774,12 @@ def test_agent_loop_interval_above_max_detected():
 
 
 def test_api_key_set_with_plants_passes():
-    raw = {"anthropic": {"api_key": "sk-fake"}, "plants": [_base_plant()]}
+    raw = {"anthropic": {"api_key": "sk-ant-" + "x" * 20}, "plants": [_base_plant()]}
     assert validate_config(raw) == []
 
 
 def test_api_key_set_with_no_plants_detected():
-    raw = {"anthropic": {"api_key": "sk-fake"}, "plants": []}
+    raw = {"anthropic": {"api_key": "sk-ant-" + "x" * 20}, "plants": []}
     errors = validate_config(raw)
     assert any("plants" in e for e in errors)
 
@@ -802,3 +802,20 @@ def test_pump_gpio_non_reserved_passes():
         p = _base_plant(pump_gpio=pin)
         raw = {"plants": [p]}
         assert validate_config(raw) == [], f"Expected no errors for pin {pin}"
+
+
+def test_api_key_valid_passes():
+    raw = {"anthropic": {"api_key": "sk-ant-" + "x" * 20}, "plants": [_base_plant()]}
+    assert validate_config(raw) == []
+
+
+def test_api_key_too_short_detected():
+    raw = {"anthropic": {"api_key": "sk-short"}, "plants": [_base_plant()]}
+    errors = validate_config(raw)
+    assert any("api_key" in e for e in errors)
+
+
+def test_api_key_with_space_detected():
+    raw = {"anthropic": {"api_key": "sk-ant-valid key with space"}, "plants": [_base_plant()]}
+    errors = validate_config(raw)
+    assert any("api_key" in e for e in errors)


### PR DESCRIPTION
## Summary
- Returns an error if `api_key` is set but shorter than 20 characters or contains whitespace
- Updates all test fixtures that used short fake keys (`"sk-test"`, `"sk-fake"`, `"sk-fake-key"`) to use a valid-length placeholder

Closes #121

## Test plan
- [ ] `pytest tests/test_config_validation.py tests/test_config.py -q` passes (145 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)