### PR TITLE
Config: restrict camera_index to 0-9

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -246,9 +246,9 @@ def validate_config(raw: dict) -> list[str]:
             )
 
         camera_index = p.get("camera_index")
-        if camera_index is not None and camera_index < 0:
+        if camera_index is not None and not (0 <= camera_index <= 9):
             errors.append(
-                f"{label}: camera_index must be >= 0 (got {camera_index!r})"
+                f"{label}: camera_index must be 0-9 (got {camera_index!r})"
             )
 
         notes = p.get("notes")

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -819,3 +819,15 @@ def test_api_key_with_space_detected():
     raw = {"anthropic": {"api_key": "sk-ant-valid key with space"}, "plants": [_base_plant()]}
     errors = validate_config(raw)
     assert any("api_key" in e for e in errors)
+
+
+def test_camera_index_valid_passes():
+    for idx in (0, 1, 9):
+        raw = {"plants": [_base_plant(camera_index=idx)]}
+        assert validate_config(raw) == [], f"Expected no errors for camera_index={idx}"
+
+
+def test_camera_index_above_max_detected():
+    raw = {"plants": [_base_plant(camera_index=10)]}
+    errors = validate_config(raw)
+    assert any("camera_index" in e for e in errors)


### PR DESCRIPTION
## Summary
- Changes `camera_index` check from `>= 0` to `0 <= camera_index <= 9`
- A Raspberry Pi typically has at most 2 cameras; index > 9 is certainly a misconfiguration

Closes #122

## Test plan
- [ ] `pytest tests/test_config_validation.py tests/test_config.py -q` passes (147 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)