### PR TITLE
Config: guard moisture min/max cross-field check against non-integer values

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -200,7 +200,11 @@ def validate_config(raw: dict) -> list[str]:
             errors.append(
                 f"{label}: moisture_target_max must be 0-100 (got {mx!r})"
             )
-        if mn is not None and mx is not None and mn >= mx:
+        if (
+            mn is not None and mx is not None
+            and isinstance(mn, int) and isinstance(mx, int)
+            and mn >= mx
+        ):
             errors.append(
                 f"{label}: moisture_target_min ({mn}) must be less than moisture_target_max ({mx})"
             )

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -848,3 +848,11 @@ def test_notes_control_char_detected():
     raw = {"plants": [_base_plant(notes="bad\x01char")]}
     errors = validate_config(raw)
     assert any("notes" in e and "control" in e for e in errors)
+
+
+def test_moisture_float_min_no_false_cross_field_error():
+    """A float moisture_target_min should produce a type error but NOT a cross-field error."""
+    raw = {"plants": [_base_plant(moisture_target_min=20.5, moisture_target_max=70)]}
+    errors = validate_config(raw)
+    assert any("moisture_target_min" in e and "integer" in e for e in errors)
+    assert not any("must be less than" in e for e in errors)


### PR DESCRIPTION
## Summary
- Adds `isinstance(mn, int) and isinstance(mx, int)` guard to the `mn >= mx` cross-field check so it only runs when both values passed their individual type checks
- Prevents a false "must be less than" error from appearing alongside a "must be an integer" error

Closes #129

## Test plan
- [ ] `pytest tests/test_config_validation.py -q` passes (132 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)