### PR TITLE
Config: reject db_path containing control characters

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -96,6 +96,8 @@ def validate_config(raw: dict) -> list[str]:
     db_path = app.get("db_path")
     if db_path is not None and not db_path:
         errors.append("[app] db_path must not be empty")
+    elif db_path is not None and any(ord(c) < 32 for c in db_path):
+        errors.append("[app] db_path must not contain control characters")
 
     telegram = raw.get("telegram", {})
     tg_token = telegram.get("token", "")

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -374,6 +374,18 @@ def test_db_path_absent_passes():
     assert validate_config(raw) == []
 
 
+def test_db_path_null_byte_detected():
+    raw = {"app": {"db_path": "flora\x00.db"}, "plants": [_base_plant()]}
+    errors = validate_config(raw)
+    assert any("db_path" in e for e in errors)
+
+
+def test_db_path_control_char_detected():
+    raw = {"app": {"db_path": "flora\x01.db"}, "plants": [_base_plant()]}
+    errors = validate_config(raw)
+    assert any("db_path" in e for e in errors)
+
+
 def test_notes_too_long_detected():
     raw = {"plants": [_base_plant(notes="x" * 501)]}
     errors = validate_config(raw)


### PR DESCRIPTION
## Summary
- Added control character check for `db_path` in `validate_config`: rejects paths containing any character with ASCII code < 32 (null bytes, control chars)
- Uses `elif` to avoid double-reporting when `db_path` is also empty
- Added `test_db_path_null_byte_detected` and `test_db_path_control_char_detected` tests

## Test plan
- [ ] `pytest tests/test_config_validation.py -q` → 136 passed

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)