### PR TITLE
Config: enforce model min length 3 and raise max to 200 chars

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -126,8 +126,10 @@ def validate_config(raw: dict) -> list[str]:
     model = anthropic.get("model")
     if model is not None and not model:
         errors.append("[anthropic] model must not be empty")
-    elif model is not None and len(model) > 100:
-        errors.append(f"[anthropic] model must be <= 100 characters (got {len(model)})")
+    elif model is not None and len(model) < 3:
+        errors.append(f"[anthropic] model must be at least 3 characters (got {len(model)})")
+    elif model is not None and len(model) > 200:
+        errors.append(f"[anthropic] model must be <= 200 characters (got {len(model)})")
     elif model is not None and any(c in model for c in (" ", "\t", "\n")):
         errors.append(f"[anthropic] model must not contain whitespace (got {model!r})")
 

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -673,7 +673,7 @@ def test_model_valid_passes():
 
 
 def test_model_too_long_detected():
-    raw = {"anthropic": {"api_key": "sk-ant-" + "x" * 20, "model": "x" * 101}, "plants": [_base_plant()]}
+    raw = {"anthropic": {"api_key": "sk-ant-" + "x" * 20, "model": "x" * 201}, "plants": [_base_plant()]}
     errors = validate_config(raw)
     assert any("model" in e for e in errors)
 
@@ -690,8 +690,19 @@ def test_model_with_newline_detected():
     assert any("model" in e for e in errors)
 
 
-def test_model_exactly_100_chars_passes():
-    raw = {"anthropic": {"api_key": "sk-ant-" + "x" * 20, "model": "a" * 100}, "plants": [_base_plant()]}
+def test_model_exactly_200_chars_passes():
+    raw = {"anthropic": {"api_key": "sk-ant-" + "x" * 20, "model": "a" * 200}, "plants": [_base_plant()]}
+    assert validate_config(raw) == []
+
+
+def test_model_too_short_detected():
+    raw = {"anthropic": {"api_key": "sk-ant-" + "x" * 20, "model": "ab"}, "plants": [_base_plant()]}
+    errors = validate_config(raw)
+    assert any("model" in e for e in errors)
+
+
+def test_model_min_length_passes():
+    raw = {"anthropic": {"api_key": "sk-ant-" + "x" * 20, "model": "abc"}, "plants": [_base_plant()]}
     assert validate_config(raw) == []
 
 


### PR DESCRIPTION
## Summary
- Added minimum length check: `model` must be at least 3 characters (rejects `"ab"`, `"a"`, etc.)
- Raised maximum length from 100 to 200 characters to accommodate longer future model IDs
- Updated `test_model_too_long_detected` to use 201-char string (was 101)
- Renamed `test_model_exactly_100_chars_passes` → `test_model_exactly_200_chars_passes`
- Added `test_model_too_short_detected` and `test_model_min_length_passes`

## Test plan
- [ ] `pytest tests/test_config_validation.py -q` → 138 passed

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)