### PR TITLE
Config: reject notes that are whitespace-only

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -272,6 +272,8 @@ def validate_config(raw: dict) -> list[str]:
             ord(c) < 32 and c not in ("\t", "\n") for c in notes
         ):
             errors.append(f"{label}: notes must not contain control characters")
+        if notes is not None and notes and not notes.strip():
+            errors.append(f"{label}: notes must not be whitespace-only")
 
     seen_plug_aliases: set[str] = set()
     seen_plug_hosts: set[str] = set()

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -886,6 +886,24 @@ def test_notes_control_char_detected():
     assert any("notes" in e and "control" in e for e in errors)
 
 
+def test_notes_whitespace_only_detected():
+    raw = {"plants": [_base_plant(notes="   ")]}
+    errors = validate_config(raw)
+    assert any("notes" in e and "whitespace" in e for e in errors)
+
+
+def test_notes_whitespace_only_tabs_detected():
+    raw = {"plants": [_base_plant(notes="\t\t")]}
+    errors = validate_config(raw)
+    assert any("notes" in e and "whitespace" in e for e in errors)
+
+
+def test_notes_with_content_and_spaces_passes():
+    raw = {"plants": [_base_plant(notes="  some note  ")]}
+    errors = validate_config(raw)
+    assert not any("whitespace" in e for e in errors)
+
+
 def test_moisture_float_min_no_false_cross_field_error():
     """A float moisture_target_min should produce a type error but NOT a cross-field error."""
     raw = {"plants": [_base_plant(moisture_target_min=20.5, moisture_target_max=70)]}


### PR DESCRIPTION
## Summary
- Adds validation to reject `notes` fields containing only whitespace (spaces, tabs, newlines)
- Non-empty notes with surrounding whitespace (e.g. `"  some note  "`) still pass
- Closes #144

## Test plan
- `test_notes_whitespace_only_detected` — spaces-only triggers error
- `test_notes_whitespace_only_tabs_detected` — tabs-only triggers error
- `test_notes_with_content_and_spaces_passes` — padded content passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)