### PR TITLE
Config: reject whitespace-only db_path

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -96,6 +96,8 @@ def validate_config(raw: dict) -> list[str]:
     db_path = app.get("db_path")
     if db_path is not None and not db_path:
         errors.append("[app] db_path must not be empty")
+    elif db_path is not None and db_path and not db_path.strip():
+        errors.append("[app] db_path must not be whitespace-only")
     elif db_path is not None and any(ord(c) < 32 for c in db_path):
         errors.append("[app] db_path must not contain control characters")
 

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -393,6 +393,18 @@ def test_db_path_control_char_detected():
     assert any("db_path" in e for e in errors)
 
 
+def test_db_path_whitespace_only_detected():
+    raw = {"app": {"db_path": "   "}, "plants": [_base_plant()]}
+    errors = validate_config(raw)
+    assert any("db_path" in e and "whitespace" in e for e in errors)
+
+
+def test_db_path_whitespace_only_tabs_detected():
+    raw = {"app": {"db_path": "\t\t"}, "plants": [_base_plant()]}
+    errors = validate_config(raw)
+    assert any("db_path" in e and "whitespace" in e for e in errors)
+
+
 def test_notes_too_long_detected():
     raw = {"plants": [_base_plant(notes="x" * 501)]}
     errors = validate_config(raw)


### PR DESCRIPTION
## Summary
- Adds validation to reject `db_path` values that are non-empty but contain only whitespace (spaces, tabs)
- Inserts as an `elif` branch between the empty-string check and the control-character check
- Closes #147

## Test plan
- `test_db_path_whitespace_only_detected` — spaces-only triggers error
- `test_db_path_whitespace_only_tabs_detected` — tabs-only triggers error

🤖 Generated with [Claude Code](https://claude.com/claude-code)