### PR TITLE
Config: reject loopback addresses for smart plug host

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -307,6 +307,10 @@ def validate_config(raw: dict) -> list[str]:
                 errors.append(
                     f"{label}: host must be a valid IPv4 address or hostname (got {host!r})"
                 )
+            elif host in ("localhost", "127.0.0.1", "::1"):
+                errors.append(
+                    f"{label}: host must not be a loopback address (got {host!r})"
+                )
             if host in seen_plug_hosts:
                 errors.append(f"{label}: duplicate host '{host}'")
             else:

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -636,6 +636,30 @@ def test_plug_host_invalid_format_detected():
         assert any("host" in e for e in errors), f"Expected error for host={host!r}"
 
 
+def test_plug_host_loopback_ipv4_detected():
+    raw = {"plants": [], "smart_plugs": [_base_plug(host="127.0.0.1")]}
+    errors = validate_config(raw)
+    assert any("loopback" in e for e in errors)
+
+
+def test_plug_host_localhost_detected():
+    raw = {"plants": [], "smart_plugs": [_base_plug(host="localhost")]}
+    errors = validate_config(raw)
+    assert any("loopback" in e for e in errors)
+
+
+def test_plug_host_loopback_ipv6_detected():
+    # ::1 fails the format check (not a valid IPv4/hostname) before reaching loopback check
+    raw = {"plants": [], "smart_plugs": [_base_plug(host="::1")]}
+    errors = validate_config(raw)
+    assert any("host" in e for e in errors)
+
+
+def test_plug_host_lan_address_passes():
+    raw = {"plants": [], "smart_plugs": [_base_plug(host="192.168.1.10")]}
+    assert validate_config(raw) == []
+
+
 def test_plant_name_valid_chars_pass():
     for name in ("basil", "my-herb", "herb_1", "Mint", "coriander-2"):
         raw = {"plants": [_base_plant(name=name)]}


### PR DESCRIPTION
## Summary
- Adds validation to reject `localhost`, `127.0.0.1`, and `::1` as smart plug hosts (likely misconfiguration)
- Note: `::1` is already rejected by the existing IPv4/hostname format check; the new loopback check covers `localhost` and `127.0.0.1`
- Closes #148

## Test plan
- `test_plug_host_loopback_ipv4_detected` — `127.0.0.1` triggers loopback error
- `test_plug_host_localhost_detected` — `localhost` triggers loopback error
- `test_plug_host_loopback_ipv6_detected` — `::1` triggers format error (caught before loopback check)
- `test_plug_host_lan_address_passes` — `192.168.1.10` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)