### PR TITLE
Config: reject reserved role names as smart plug alias

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -294,6 +294,10 @@ def validate_config(raw: dict) -> list[str]:
                 errors.append(
                     f"{label}: alias must contain only letters, digits, underscores, or hyphens (got {alias!r})"
                 )
+            elif alias in ("grow_light", "humidifier", "fan"):
+                errors.append(
+                    f"{label}: alias must not be a reserved role name (got {alias!r})"
+                )
             if alias in seen_plug_aliases:
                 errors.append(f"{label}: duplicate alias '{alias}'")
             else:

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -492,7 +492,7 @@ def test_smart_plug_unique_aliases_pass():
         "plants": [],
         "smart_plugs": [
             _base_plug(alias="grow-light", host="192.168.1.10"),
-            _base_plug(alias="humidifier", host="192.168.1.11", role="humidifier"),
+            _base_plug(alias="my-humidifier", host="192.168.1.11", role="humidifier"),
         ],
     }
     assert validate_config(raw) == []
@@ -515,7 +515,7 @@ def test_smart_plug_unique_hosts_pass():
         "plants": [],
         "smart_plugs": [
             _base_plug(alias="grow-light", host="192.168.1.10"),
-            _base_plug(alias="humidifier", host="192.168.1.11", role="humidifier"),
+            _base_plug(alias="my-humidifier", host="192.168.1.11", role="humidifier"),
         ],
     }
     assert validate_config(raw) == []
@@ -686,7 +686,7 @@ def test_plant_name_empty_detected():
 
 
 def test_plug_alias_valid_chars_pass():
-    for alias in ("grow-light", "humidifier_1", "fan", "MyFan"):
+    for alias in ("grow-light", "humidifier_1", "my-fan", "MyFan"):
         raw = {"plants": [], "smart_plugs": [_base_plug(alias=alias)]}
         assert validate_config(raw) == [], f"Expected no errors for alias={alias!r}"
 
@@ -708,6 +708,24 @@ def test_plug_alias_empty_detected():
     raw = {"plants": [], "smart_plugs": [_base_plug(alias="")]}
     errors = validate_config(raw)
     assert any("alias" in e for e in errors)
+
+
+def test_plug_alias_reserved_role_grow_light_detected():
+    raw = {"plants": [], "smart_plugs": [_base_plug(alias="grow_light")]}
+    errors = validate_config(raw)
+    assert any("alias" in e and "reserved" in e for e in errors)
+
+
+def test_plug_alias_reserved_role_humidifier_detected():
+    raw = {"plants": [], "smart_plugs": [_base_plug(alias="humidifier")]}
+    errors = validate_config(raw)
+    assert any("alias" in e and "reserved" in e for e in errors)
+
+
+def test_plug_alias_reserved_role_fan_detected():
+    raw = {"plants": [], "smart_plugs": [_base_plug(alias="fan")]}
+    errors = validate_config(raw)
+    assert any("alias" in e and "reserved" in e for e in errors)
 
 
 def test_model_valid_passes():


### PR DESCRIPTION
## Summary
- Adds validation to reject aliases that match reserved role strings: `grow_light`, `humidifier`, `fan`
- These collide with `plug_by_role()` semantics and are likely misconfiguration
- Updates two existing tests that used `"humidifier"` as a valid alias (now invalid)
- Closes #151

## Test plan
- `test_plug_alias_reserved_role_grow_light_detected` — `grow_light` alias rejected
- `test_plug_alias_reserved_role_humidifier_detected` — `humidifier` alias rejected
- `test_plug_alias_reserved_role_fan_detected` — `fan` alias rejected
- `test_plug_alias_valid_chars_pass` updated: `"fan"` → `"my-fan"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)