### PR TITLE
Config: reject sensor_poll_interval >= agent_loop_interval

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -87,6 +87,17 @@ def validate_config(raw: dict) -> list[str]:
         elif val is not None and not (1 <= val <= 86400):
             errors.append(f"[app] {field_name} must be 1-86400 (got {val!r})")
 
+    poll = app.get("sensor_poll_interval")
+    loop = app.get("agent_loop_interval")
+    if (
+        poll is not None and loop is not None
+        and isinstance(poll, int) and isinstance(loop, int)
+        and poll >= loop
+    ):
+        errors.append(
+            f"[app] sensor_poll_interval ({poll}) must be less than agent_loop_interval ({loop})"
+        )
+
     port = app.get("dashboard_port")
     if port is not None and not isinstance(port, int):
         errors.append(f"[app] dashboard_port must be an integer (got {port!r})")

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -571,6 +571,23 @@ def test_interval_integer_values_pass():
     assert validate_config(raw) == []
 
 
+def test_poll_interval_equal_to_loop_interval_detected():
+    raw = {"app": {"sensor_poll_interval": 3600, "agent_loop_interval": 3600}, "plants": []}
+    errors = validate_config(raw)
+    assert any("sensor_poll_interval" in e and "agent_loop_interval" in e for e in errors)
+
+
+def test_poll_interval_greater_than_loop_interval_detected():
+    raw = {"app": {"sensor_poll_interval": 7200, "agent_loop_interval": 3600}, "plants": []}
+    errors = validate_config(raw)
+    assert any("sensor_poll_interval" in e and "agent_loop_interval" in e for e in errors)
+
+
+def test_poll_interval_less_than_loop_interval_passes():
+    raw = {"app": {"sensor_poll_interval": 1800, "agent_loop_interval": 7200}, "plants": []}
+    assert not any("agent_loop_interval" in e and "sensor_poll_interval" in e for e in validate_config(raw))
+
+
 def test_dashboard_port_float_detected():
     raw = {"app": {"dashboard_port": 8000.0}, "plants": []}
     errors = validate_config(raw)


### PR DESCRIPTION
## Summary
- Adds cross-field validation: if both intervals are set and valid integers, `sensor_poll_interval` must be strictly less than `agent_loop_interval`
- Guards with `isinstance` checks to avoid double-reporting when either value has a type error
- Closes #152

## Test plan
- `test_poll_interval_equal_to_loop_interval_detected` — equal values rejected
- `test_poll_interval_greater_than_loop_interval_detected` — poll > loop rejected
- `test_poll_interval_less_than_loop_interval_passes` — valid ordering passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)