### PR TITLE
Fix: revert alias reserved-role check; update short api_key test fixtures

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -305,10 +305,6 @@ def validate_config(raw: dict) -> list[str]:
                 errors.append(
                     f"{label}: alias must contain only letters, digits, underscores, or hyphens (got {alias!r})"
                 )
-            elif alias in ("grow_light", "humidifier", "fan"):
-                errors.append(
-                    f"{label}: alias must not be a reserved role name (got {alias!r})"
-                )
             if alias in seen_plug_aliases:
                 errors.append(f"{label}: duplicate alias '{alias}'")
             else:

--- a/tests/test_actuators.py
+++ b/tests/test_actuators.py
@@ -66,7 +66,7 @@ def _make_config(tmp_path: Path) -> "AppConfig":
     import textwrap
     toml_text = textwrap.dedent("""\
         [anthropic]
-        api_key = "sk-test"
+        api_key = "sk-ant-xxxxxxxxxxxxxxxxxxxx"
         model   = "claude-haiku-4-5-20251001"
 
         [telegram]
@@ -152,7 +152,7 @@ async def test_set_light_schedule_no_plug_configured(tmp_path: Path) -> None:
     import textwrap
     toml_text = textwrap.dedent("""\
         [anthropic]
-        api_key = "sk-test"
+        api_key = "sk-ant-xxxxxxxxxxxxxxxxxxxx"
         model   = "claude-haiku-4-5-20251001"
 
         [telegram]

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -46,7 +46,7 @@ async def db(tmp_path):
 @pytest.fixture
 def config(tmp_path):
     toml = tmp_path / "flora.toml"
-    toml.write_text(_TOML_BASE.format(api_key="test-key"))
+    toml.write_text(_TOML_BASE.format(api_key="sk-ant-xxxxxxxxxxxxxxxxxxxx"))
     return load_config(str(toml))
 
 
@@ -61,7 +61,7 @@ async def test_agent_loop_runs_without_error(config, db):
 async def test_fallback_runs_when_api_key_invalid(tmp_path, db):
     """Fallback rule-based loop runs when API key is invalid."""
     toml = tmp_path / "flora.toml"
-    toml.write_text(_TOML_BASE.format(api_key="sk-ant-invalid"))
+    toml.write_text(_TOML_BASE.format(api_key="sk-ant-invalidxxxxxxxxxxxxxxx"))
     config = load_config(str(toml))
     loop = AgentLoop(config, db)
     # Invalid key → fallback. Should not raise.

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -492,7 +492,7 @@ def test_smart_plug_unique_aliases_pass():
         "plants": [],
         "smart_plugs": [
             _base_plug(alias="grow-light", host="192.168.1.10"),
-            _base_plug(alias="my-humidifier", host="192.168.1.11", role="humidifier"),
+            _base_plug(alias="humidifier", host="192.168.1.11", role="humidifier"),
         ],
     }
     assert validate_config(raw) == []
@@ -515,7 +515,7 @@ def test_smart_plug_unique_hosts_pass():
         "plants": [],
         "smart_plugs": [
             _base_plug(alias="grow-light", host="192.168.1.10"),
-            _base_plug(alias="my-humidifier", host="192.168.1.11", role="humidifier"),
+            _base_plug(alias="humidifier", host="192.168.1.11", role="humidifier"),
         ],
     }
     assert validate_config(raw) == []
@@ -703,7 +703,7 @@ def test_plant_name_empty_detected():
 
 
 def test_plug_alias_valid_chars_pass():
-    for alias in ("grow-light", "humidifier_1", "my-fan", "MyFan"):
+    for alias in ("grow-light", "humidifier_1", "fan", "MyFan"):
         raw = {"plants": [], "smart_plugs": [_base_plug(alias=alias)]}
         assert validate_config(raw) == [], f"Expected no errors for alias={alias!r}"
 
@@ -725,24 +725,6 @@ def test_plug_alias_empty_detected():
     raw = {"plants": [], "smart_plugs": [_base_plug(alias="")]}
     errors = validate_config(raw)
     assert any("alias" in e for e in errors)
-
-
-def test_plug_alias_reserved_role_grow_light_detected():
-    raw = {"plants": [], "smart_plugs": [_base_plug(alias="grow_light")]}
-    errors = validate_config(raw)
-    assert any("alias" in e and "reserved" in e for e in errors)
-
-
-def test_plug_alias_reserved_role_humidifier_detected():
-    raw = {"plants": [], "smart_plugs": [_base_plug(alias="humidifier")]}
-    errors = validate_config(raw)
-    assert any("alias" in e and "reserved" in e for e in errors)
-
-
-def test_plug_alias_reserved_role_fan_detected():
-    raw = {"plants": [], "smart_plugs": [_base_plug(alias="fan")]}
-    errors = validate_config(raw)
-    assert any("alias" in e and "reserved" in e for e in errors)
 
 
 def test_model_valid_passes():

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -15,7 +15,7 @@ sensor_poll_interval = 1800
 agent_loop_interval = 7200
 
 [anthropic]
-api_key = "test"
+api_key = "sk-ant-xxxxxxxxxxxxxxxxxxxx"
 model = "claude-haiku-4-5-20251001"
 
 [telegram]


### PR DESCRIPTION
## Summary
- Reverts the alias reserved-role validation from PR #153 — the premise was wrong. `plug_by_role()` looks up by `role` not `alias`, so naming an alias `grow_light` causes no collision.
- Fixes `test_actuators`, `test_agent_loop`, and `test_dashboard` which used API keys shorter than 20 chars (now rejected by validation added in earlier PRs). Updated to use `sk-ant-xxxxxxxxxxxxxxxxxxxx`.

## Root cause
PR #153 introduced a bogus validation rule that broke real usage patterns and existing tests. The fix removes it entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)