### PR TITLE
Fix: align auto_water_duration_seconds validation range to 5-30

### DIFF
--- a/src/flora/config.py
+++ b/src/flora/config.py
@@ -40,7 +40,7 @@ class PlantConfig:
     moisture_target_max: int = 70
     # Optional deterministic auto-water rule (no Claude API needed)
     auto_water_if_below: int | None = None   # moisture % threshold
-    auto_water_duration_seconds: int = 8     # pump seconds (clamped 5-30)
+    auto_water_duration_seconds: int = 8     # pump seconds (5-30)
     auto_water_min_interval_minutes: int = 15  # minimum minutes between auto-water firings
     # Camera assignment (index into Picamera2 camera list; None = default 0)
     camera_index: int | None = None
@@ -231,9 +231,9 @@ def validate_config(raw: dict) -> list[str]:
             errors.append(
                 f"{label}: auto_water_duration_seconds must be an integer (got {duration!r})"
             )
-        elif duration is not None and not (1 <= duration <= 30):
+        elif duration is not None and not (5 <= duration <= 30):
             errors.append(
-                f"{label}: auto_water_duration_seconds must be 1-30 (got {duration!r})"
+                f"{label}: auto_water_duration_seconds must be 5-30 (got {duration!r})"
             )
 
         interval = p.get("auto_water_min_interval_minutes")

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -146,9 +146,10 @@ def test_load_config_raises_on_invalid(tmp_path):
 
 
 def test_auto_water_duration_too_low_detected():
-    raw = {"plants": [_base_plant(auto_water_duration_seconds=0)]}
-    errors = validate_config(raw)
-    assert any("auto_water_duration_seconds" in e for e in errors)
+    for val in (0, 1, 4):
+        raw = {"plants": [_base_plant(auto_water_duration_seconds=val)]}
+        errors = validate_config(raw)
+        assert any("auto_water_duration_seconds" in e for e in errors), f"Expected error for duration={val}"
 
 
 def test_auto_water_duration_too_high_detected():
@@ -158,7 +159,7 @@ def test_auto_water_duration_too_high_detected():
 
 
 def test_auto_water_duration_valid_range_passes():
-    for val in (1, 15, 30):
+    for val in (5, 15, 30):
         raw = {"plants": [_base_plant(auto_water_duration_seconds=val)]}
         assert validate_config(raw) == [], f"Expected no errors for duration={val}"
 


### PR DESCRIPTION
## Summary
- The scheduler has always enforced `max(5, min(30, duration))` at runtime, making values 1-4 silently bump to 5 seconds
- Config validation previously accepted 1-30, creating a misleading contract
- This PR changes validation to 5-30, matching what the scheduler actually does
- Closes #158

## Test plan
- `test_auto_water_duration_too_low_detected` now covers 0, 1, 4 (all rejected)
- `test_auto_water_duration_valid_range_passes` updated: 1 → 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)