### PR TITLE
DB: add composite index on action_log(plant_name, action_type, timestamp)

### DIFF
--- a/src/flora/db.py
+++ b/src/flora/db.py
@@ -59,6 +59,7 @@ CREATE INDEX IF NOT EXISTS idx_sensor_plant_ts   ON sensor_readings(plant_name, 
 CREATE INDEX IF NOT EXISTS idx_ambient_ts        ON ambient_readings(timestamp);
 CREATE INDEX IF NOT EXISTS idx_journal_plant_ts  ON plant_journals(plant_name, timestamp);
 CREATE INDEX IF NOT EXISTS idx_action_ts         ON action_log(timestamp);
+CREATE INDEX IF NOT EXISTS idx_action_plant_type_ts ON action_log(plant_name, action_type, timestamp);
 """
 
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -100,3 +100,16 @@ async def test_create_scheduler_no_plug_configured():
     job_ids = {job.id for job in scheduler.get_jobs()}
     assert "grow_light_on" not in job_ids
     assert "grow_light_off" not in job_ids
+
+
+@pytest.mark.asyncio
+async def test_action_log_composite_index_exists(tmp_path):
+    """idx_action_plant_type_ts must exist after connect() for efficient count_recent_same_action queries."""
+    db = Database(tmp_path / "test.db")
+    await db.connect()
+    async with db._conn_or_raise().execute(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_action_plant_type_ts'"
+    ) as cursor:
+        row = await cursor.fetchone()
+    await db.close()
+    assert row is not None, "idx_action_plant_type_ts index missing from action_log"


### PR DESCRIPTION
## Summary
- `count_recent_same_action()` queries `action_log` by `plant_name`, `action_type`, and `timestamp` on every sensor poll per plant
- The only existing index was `idx_action_ts` (timestamp alone), causing a full table scan filtered by plant_name/action_type
- Adds `idx_action_plant_type_ts` covering all three columns in query order
- Closes #160

## Test plan
- `test_action_log_composite_index_exists` — verifies the index is present in sqlite_master after `connect()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)