### PR TITLE
Agent: log warning when 10-iteration tool-use safety cap is hit

### DIFF
--- a/src/flora/agent/loop.py
+++ b/src/flora/agent/loop.py
@@ -118,7 +118,8 @@ class AgentLoop:
         ]
 
         # Agentic loop: continue until no more tool calls
-        for iteration in range(10):  # safety limit
+        _MAX_ITERATIONS = 10
+        for iteration in range(_MAX_ITERATIONS):  # safety limit
             response = await self._client.messages.create(
                 model=self._config.anthropic_model,
                 max_tokens=4096,
@@ -135,6 +136,14 @@ class AgentLoop:
             if not tool_uses:
                 # No more tool calls — agent is done
                 logger.info("Agent loop completed after %d iterations", iteration + 1)
+                break
+
+            if iteration == _MAX_ITERATIONS - 1:
+                logger.warning(
+                    "Agent loop hit %d-iteration safety cap without reaching end_turn — "
+                    "possible runaway tool loop",
+                    _MAX_ITERATIONS,
+                )
                 break
 
             # Execute all tool calls

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1,5 +1,7 @@
 """End-to-end agent loop tests — real API (skipped if key not set) + fallback."""
+import logging
 import os
+from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from flora.config import load_config
 from flora.db import Database
@@ -66,3 +68,28 @@ async def test_fallback_runs_when_api_key_invalid(tmp_path, db):
     loop = AgentLoop(config, db)
     # Invalid key → fallback. Should not raise.
     await loop.run_once()
+
+
+async def test_iteration_cap_logs_warning(config, db, caplog):
+    """Agent loop logs a warning when the 10-iteration safety cap is hit."""
+    # Simulate Claude always returning a tool_use so the cap is reached
+    fake_tool_use = MagicMock()
+    fake_tool_use.type = "tool_use"
+    fake_tool_use.name = "water_plant"
+    fake_tool_use.id = "tu_fake"
+    fake_tool_use.input = {"plant_name": "basil-1", "duration_seconds": 5}
+
+    fake_response = MagicMock()
+    fake_response.stop_reason = "tool_use"
+    fake_response.content = [fake_tool_use]
+
+    with patch.object(
+        loop := AgentLoop(config, db),
+        "_client",
+    ):
+        loop._client.messages.create = AsyncMock(return_value=fake_response)
+        loop._executor.execute = AsyncMock(return_value="ok")
+        with caplog.at_level(logging.WARNING, logger="flora.agent.loop"):
+            await loop._run_claude_loop()
+
+    assert any("safety cap" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- The agentic tool-use loop runs at most 10 iterations for safety, but previously exited silently when hitting the cap
- A runaway tool loop would be completely invisible in production logs
- Now logs `WARNING: Agent loop hit 10-iteration safety cap without reaching end_turn — possible runaway tool loop`
- The cap check runs before executing the final batch to avoid unnecessary tool calls at the boundary
- Closes #162

## Test plan
- `test_iteration_cap_logs_warning` — mocks Claude to always return a tool_use, verifies WARNING is emitted after 10 iterations

🤖 Generated with [Claude Code](https://claude.com/claude-code)