### PR TITLE
Dashboard: clamp manual water to 5s minimum, matching agent and scheduler

### DIFF
--- a/src/flora/dashboard/routes.py
+++ b/src/flora/dashboard/routes.py
@@ -99,7 +99,7 @@ def create_router(
         plant = config.plant_by_name(name)
         if plant is None:
             return HTMLResponse("<p>Plant not found</p>", status_code=404)
-        duration = max(1, min(duration, 30))  # clamp 1-30s
+        duration = max(5, min(duration, 30))  # clamp 5-30s, matching agent and scheduler
         from flora.actuators.pump import water_plant as _pump
         from flora.db import ActionRecord
         success = await _pump(plant.pump_gpio, duration)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -72,6 +72,20 @@ async def test_manual_water_unknown_plant(client):
     assert resp.status_code == 404
 
 
+async def test_manual_water_clamps_below_minimum(client):
+    """Duration below 5s is clamped to 5, matching agent and scheduler minimum."""
+    resp = await client.post("/plants/basil-1/water", data={"duration": "1"})
+    assert resp.status_code == 200
+    assert "5s" in resp.text
+
+
+async def test_manual_water_clamps_above_maximum(client):
+    """Duration above 30s is clamped to 30."""
+    resp = await client.post("/plants/basil-1/water", data={"duration": "120"})
+    assert resp.status_code == 200
+    assert "30s" in resp.text
+
+
 # --- Mock species data helpers ---
 
 def test_mock_moisture_known_species():


### PR DESCRIPTION
## Summary
- Changes `max(1, ...)` to `max(5, ...)` in the dashboard manual water endpoint so the minimum matches the 5s floor enforced by the agent tool and scheduler auto-water
- Adds two tests asserting the clamp behaviour at both ends of the range

## Test plan
- [ ] `pytest tests/test_dashboard.py` — all 19 tests pass including the two new clamp tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)